### PR TITLE
Add FastAPI Stremio addon powered by OpenRouter Gemini 2.5 Flash Lite

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,8 @@
+# Copy to .env and fill in your credentials
+OPENROUTER_API_KEY=replace-with-your-openrouter-key
+OPENROUTER_MODEL=google/gemini-2.5-flash-lite
+TRAKT_CLIENT_ID=replace-with-trakt-client-id
+TRAKT_ACCESS_TOKEN=replace-with-trakt-access-token
+CATALOG_COUNT=6
+REFRESH_INTERVAL=43200
+CACHE_TTL=1800

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+.env.*
+!.env.sample
+.pytest_cache/
+coverage/
+aiopicks.egg-info/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY pyproject.toml README.md ./
+COPY app ./app
+COPY .env.sample ./
+
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir .
+
+EXPOSE 3000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "3000"]

--- a/README.md
+++ b/README.md
@@ -94,10 +94,31 @@ uvicorn app.main:app --reload --port 3000
 Open `http://localhost:3000/manifest.json` to confirm the addon is running. Install the manifest URL in Stremio to see
 the AI-generated catalogs.
 
+### Option 3: Manual Docker CLI
+
+Prefer a one-off container instead of Compose? Build and run directly with Docker:
+
+```bash
+docker build -t aiopicks .
+docker run -d \
+  --name aiopicks \
+  -p 3000:3000 \
+  --env-file .env \
+  aiopicks
+```
+
 ## 🧪 Local Development
 
-Use the Python environment instructions above while developing locally. Run the FastAPI server with `uvicorn` in reload
-mode and iterate on the addon code. Environment variables are loaded from `.env` on startup.
+Follow the Python environment workflow while iterating:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+uvicorn app.main:app --reload --port 3000
+```
+
+Environment variables in `.env` are loaded automatically on startup.
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -1,189 +1,137 @@
 <h1 align="center">AIOPicks</h1>
 
 <p align="center">
-  <strong>AI-powered personalized recommendations for your next binge.</strong>
-  <br />
-  AIOPicks generates dynamic movie and TV show catalogs based on your Trakt watch history using advanced AI models from OpenRouter.
+  <strong>AI-powered personalized recommendations for your next binge.</strong><br />
+  AIOPicks generates dynamic movie and TV show catalogs for Stremio using your Trakt history and
+  OpenRouter's <code>google/gemini-2.5-flash-lite</code> model.
 </p>
 
 ---
 
 ## ✨ What is AIOPicks?
 
-AIOPicks revolutionizes content discovery by creating Netflix-style personalized catalogs for Stremio. Instead of browsing endless generic lists, AIOPicks analyzes your Trakt watch history and generates AI-powered recommendations tailored specifically to your viewing patterns and preferences.
+AIOPicks is a FastAPI-powered Stremio addon that turns your Trakt watch history into AI-curated, ever-changing
+catalogs. Every refresh uses the Gemini 2.5 Flash Lite model on OpenRouter to craft brand-new themes, names, and
+recommendations so you never scroll the same rows twice.
 
-Using advanced AI models from OpenRouter, AIOPicks creates dynamic catalogs that refresh automatically, ensuring you always have fresh, personalized content to discover.
+Because everything runs on your own server, your data never leaves your control. Connect your Trakt account, provide an
+OpenRouter API key, and enjoy endlessly fresh discovery playlists.
 
 ## 🚀 Key Features
 
 ### 🤖 AI-Powered Personalization
-- **Trakt Integration**: Analyzes your complete watch history, ratings, and viewing patterns
-- **OpenRouter AI**: Leverages cutting-edge AI models (GPT-4, Claude, etc.) for intelligent recommendations
-- **Dynamic Generation**: No hardcoded lists - everything is AI-generated based on your unique preferences
-- **Privacy-Focused**: Your data stays yours - all processing happens on your instance
+- **Trakt Integration**: Pulls your watch history (movies & series) with extended metadata
+- **OpenRouter AI**: Uses `google/gemini-2.5-flash-lite` for imaginative yet grounded catalog ideas
+- **Randomized Catalogs**: Each refresh injects a random seed so names and picks are always surprising
+- **Privacy-Focused**: All history processing and AI prompts happen on your self-hosted instance
 
 ### 📊 User-Configurable Dynamic Catalogs
+AIOPicks invents themed rows with bespoke names and contents:
 
-AIOPicks generates personalized catalogs with AI-generated names you won't know beforehand:
+- **🌙 Midnight Mystery Flights** – *Atmospheric thrillers for after dark*
+- **🎭 Seoulful Stories** – *Emotional Korean dramas aligned with your taste*
+- **🔥 Weekend Questline** – *Series primed for marathon sessions*
+- **✨ Critics' Curveballs** – *Awarded picks you somehow missed*
 
-- **🌙 Your Late Night Thrillers** - *Perfect edge-of-your-seat content for late viewing*
-- **🎭 Hidden Korean Gems You'll Love** - *Underrated content based on your patterns*
-- **🔥 Weekend Binge Adventures** - *Series perfect for your weekend marathons*
-- **✨ Critically Acclaimed Surprises** - *Award-winning content matching your taste*
+### 🧰 Flexible Configuration
+- **Catalog Count**: Choose how many movie/series rows to generate (1-12)
+- **Refresh Interval**: Control how often the AI regenerates catalogs
+- **Caching**: Lightweight in-memory cache keeps Stremio responses snappy between refreshes
+- **Fallbacks**: If the AI call fails, the addon gracefully falls back to history-based mixes
 
-### � Flexible Configuration
-- **User-Configurable Count**: Choose 3-12 personalized catalogs
-- **Custom Refresh Intervals**: Set how often catalogs refresh (daily, weekly, monthly)
-- **AI Model Selection**: Choose from any OpenRouter model
-- **Smart Caching**: Efficient storage prevents unnecessary AI API calls
+## 🛠️ Prerequisites
+- Python 3.10+
+- A Trakt account with viewing history (OAuth device authentication recommended)
+- OpenRouter API key with access to `google/gemini-2.5-flash-lite`
+- (Optional) Docker if you prefer container deployment
 
-### 🎯 Advanced Personalization
-- **Viewing Pattern Analysis**: Learns from your binge habits and rating patterns
-- **Genre Preferences**: Adapts to your favorite and avoided genres
-- **Quality Standards**: Matches your preference for critically acclaimed vs. popular content
-- **Discovery Balance**: Balances familiar comfort picks with adventurous new discoveries
+## ⚙️ Configuration
 
-## 🚀 Getting Started
+Create a `.env` file (or copy `.env.sample`) with your credentials:
 
-### Prerequisites
-- Trakt account with viewing history
-- OpenRouter API key
-- Docker (recommended) or Node.js 20+
+```env
+OPENROUTER_API_KEY=your-openrouter-key
+OPENROUTER_MODEL=google/gemini-2.5-flash-lite
+TRAKT_CLIENT_ID=your-trakt-client-id
+TRAKT_ACCESS_TOKEN=your-trakt-access-token
+CATALOG_COUNT=6
+REFRESH_INTERVAL=43200  # seconds
+CACHE_TTL=1800          # seconds
+```
 
-### 1. Get Your API Keys
+> ℹ️ You can obtain a Trakt access token by creating a personal application and using the device code flow. Store the
+> long-lived access token for this addon.
 
-**Trakt API:**
-1. Visit [Trakt API Settings](https://trakt.tv/oauth/applications/new)
-2. Create a new application
-3. Note your Client ID and Client Secret
+## 📥 Installation
 
-**OpenRouter:**
-1. Sign up at [OpenRouter.ai](https://openrouter.ai)
-2. Generate an API key from your dashboard
-3. Choose your preferred AI models
+### Option 1: Docker Compose (recommended)
 
-### 2. Deploy AIOPicks
+1. Copy the provided sample configuration: `cp .env.sample .env` and fill in your keys.
+2. Start the service with Docker Compose:
 
-**Docker (Recommended):**
+   ```bash
+   docker compose up -d
+   ```
+
+   The bundled `docker-compose.yml` builds the image, maps port `3000`, loads variables from `.env`, and enables
+   automatic restart.
+
+3. Open `http://localhost:3000/manifest.json` and add that URL to Stremio.
+4. To update the addon after pulling new code, run `docker compose up -d --build`.
+
+### Option 2: Python environment
+
+If you prefer to run the service directly on your host machine, install the dependencies and launch FastAPI manually:
+
 ```bash
-docker run -d \
-  --name aiopicks \
-  -p 3000:3000 \
-  -e TRAKT_CLIENT_ID=your_client_id \
-  -e TRAKT_CLIENT_SECRET=your_client_secret \
-  -e OPENROUTER_API_KEY=your_api_key \
-  -e DEFAULT_MODEL=gpt-4o-mini \
-  -e REFRESH_INTERVAL=86400 \
-  aiopicks:latest
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+cp .env.sample .env  # then edit with your keys
+uvicorn app.main:app --reload --port 3000
 ```
 
-**Docker Compose:**
-```yaml
-version: '3.8'
-services:
-  aiopicks:
-    build: .
-    ports:
-      - "3000:3000"
-    environment:
-      - TRAKT_CLIENT_ID=your_client_id
-      - TRAKT_CLIENT_SECRET=your_client_secret
-      - OPENROUTER_API_KEY=your_api_key
-      - DEFAULT_MODEL=gpt-4o-mini
-      - REFRESH_INTERVAL=86400
-      - DATABASE_URL=postgresql://user:password@db:5432/aiopicks
-    volumes:
-      - aiopicks_data:/app/data
-```
+Open `http://localhost:3000/manifest.json` to confirm the addon is running. Install the manifest URL in Stremio to see
+the AI-generated catalogs.
 
-**Development Setup:**
+## 🧪 Local Development
+
+Use the Python environment instructions above while developing locally. Run the FastAPI server with `uvicorn` in reload
+mode and iterate on the addon code. Environment variables are loaded from `.env` on startup.
+
+### Running Tests
+
 ```bash
-git clone <repository-url>
-cd aiopicks
-npm install
-cp .env.sample .env
-# Edit .env with your API keys
-npm run start:dev
+pytest
 ```
 
-### 3. Configure Your Setup
-1. Open `http://localhost:3000/stremio/configure`
-2. Connect your Trakt account
-3. Configure AI model preferences
-4. Set refresh intervals and catalog preferences (3-12 catalogs)
-5. Install the generated addon URL in Stremio
+## 🏗️ Architecture Overview
 
-## 🔧 Configuration
+- **FastAPI Server** (`app/main.py`): Implements Stremio manifest, catalog, and meta endpoints
+- **Catalog Service** (`app/services/catalog_generator.py`): Orchestrates Trakt ingestion, AI prompting, caching, and
+  background refresh
+- **Trakt Client** (`app/services/trakt.py`): Fetches and summarizes history with optional fallbacks
+- **OpenRouter Client** (`app/services/openrouter.py`): Calls Gemini 2.5 Flash Lite with structured prompts and parses
+  the JSON response
+- **Pydantic Models** (`app/models.py`): Validates AI output and converts it into Stremio-friendly payloads
 
-### Environment Variables
+The service keeps a short-lived cache of the last generated catalogs. A background coroutine refreshes them on the
+interval you configure. If OpenRouter is unavailable, it falls back to simple mixes derived from your watch history.
 
-| Variable | Description | Default | Required |
-|----------|-------------|---------|----------|
-| `TRAKT_CLIENT_ID` | Trakt API Client ID | - | ✅ |
-| `TRAKT_CLIENT_SECRET` | Trakt API Client Secret | - | ✅ |
-| `OPENROUTER_API_KEY` | OpenRouter API Key | - | ✅ |
-| `DEFAULT_MODEL` | Default AI model | `gpt-4o-mini` | ✅ |
-| `REFRESH_INTERVAL` | Catalog refresh interval (seconds) | `86400` (24h) | ✅ |
-| `DATABASE_URL` | Database connection string | SQLite | ❌ |
-| `REDIS_URL` | Redis connection string | - | ❌ |
-| `PORT` | Server port | `3000` | ❌ |
+## 📦 API Surface
 
-### Supported AI Models
-AIOPicks supports any model available on OpenRouter:
-- `gpt-4o-mini` (recommended for cost efficiency)
-- `gpt-4o` (best quality)
-- `claude-3.5-sonnet` (excellent for creative recommendations)
-- `llama-3.1-70b-instruct` (open-source alternative)
-- And many more...
-
-## 🏗️ Architecture
-
-AIOPicks is built with a modern, scalable architecture:
-
-- **Core Engine**: TypeScript-based recommendation engine
-- **AI Integration**: OpenRouter API for model flexibility
-- **Data Layer**: PostgreSQL/SQLite with Redis caching
-- **Frontend**: Next.js configuration interface
-- **API Server**: Express.js with Stremio protocol support
-
-## 📈 How It Works
-
-1. **Data Collection**: Securely fetches your Trakt watch history and ratings
-2. **Pattern Analysis**: AI analyzes your viewing patterns, preferences, and habits
-3. **Catalog Generation**: Creates user-configurable personalized recommendation catalogs
-4. **Smart Caching**: Stores recommendations with configurable refresh intervals
-5. **Stremio Integration**: Serves catalogs through standard Stremio protocol
-
-## 🛠️ Development
-
-### Available Scripts
-
-- `npm run start:dev` - Start development server
-- `npm run start:frontend:dev` - Start frontend development server
-- `npm run build` - Build all packages
-- `npm run test` - Run tests
-- `npm run format` - Format code with Prettier
-
-### Project Structure
-
-```
-packages/
-├── core/           # TypeScript recommendation engine
-├── frontend/       # Next.js configuration interface
-└── server/         # Express.js API server
-```
+| Endpoint | Description |
+|----------|-------------|
+| `/manifest.json` | Advertises AI-generated catalogs and metadata to Stremio |
+| `/catalog/{type}/{id}.json` | Returns the metas array for a specific catalog |
+| `/meta/{type}/{id}.json` | Provides metadata for a specific entry |
+| `/healthz` | Lightweight readiness probe |
 
 ## ⚠️ Disclaimer
 
-AIOPicks is a content discovery tool that generates recommendations based on your viewing history. It does not host, store, or distribute any copyrighted content. The recommendations are for discovery purposes only. Users are responsible for accessing content through legitimate means and complying with all applicable laws.
-
-## 🙏 Credits
-
-This project builds upon the foundational work of:
-- **[Trakt.tv](https://trakt.tv)** for providing comprehensive viewing data APIs
-- **[OpenRouter.ai](https://openrouter.ai)** for democratizing access to advanced AI models
-- **[Stremio](https://stremio.com)** for the excellent media center platform
+AIOPicks is a discovery tool. It does not host or stream content—only suggests what to watch next based on your own
+history. Always access content through legal providers and comply with applicable laws.
 
 ---
 
-**Made for self-hosting enthusiasts who want Netflix-level personalized recommendations.**
+**Built for self-hosting enthusiasts chasing endlessly fresh watchlists.**

--- a/README.md
+++ b/README.md
@@ -109,16 +109,15 @@ docker run -d \
 
 ## 🧪 Local Development
 
-Follow the Python environment workflow while iterating:
+Follow the Option 2 workflow from above to create a virtual environment and install the project in editable mode. Once
+your shell is inside the activated `.venv`, start the auto-reloading development server with:
 
 ```bash
-python -m venv .venv
-source .venv/bin/activate
-pip install -e .[dev]
 uvicorn app.main:app --reload --port 3000
 ```
 
-Environment variables in `.env` are loaded automatically on startup.
+Environment variables in `.env` are loaded automatically every time the server boots, so changes to the file take
+effect on the next restart.
 
 ### Running Tests
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,15 @@
+"""AIOPicks FastAPI application package."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+__all__ = ["app", "create_app"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in __all__:
+        module = import_module("app.main")
+        return getattr(module, name)
+    raise AttributeError(f"module 'app' has no attribute {name}")

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,57 @@
+"""Application configuration models."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Literal
+
+from pydantic import Field, HttpUrl
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Settings loaded from environment variables or a .env file."""
+
+    app_name: str = Field(default="AIOPicks", alias="APP_NAME")
+    server_host: str = Field(default="0.0.0.0", alias="HOST")
+    server_port: int = Field(default=3000, alias="PORT")
+
+    trakt_client_id: str | None = Field(default=None, alias="TRAKT_CLIENT_ID")
+    trakt_access_token: str | None = Field(default=None, alias="TRAKT_ACCESS_TOKEN")
+    trakt_history_limit: int = Field(default=500, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000)
+
+    openrouter_api_key: str = Field(alias="OPENROUTER_API_KEY")
+    openrouter_model: str = Field(
+        default="google/gemini-2.5-flash-lite", alias="OPENROUTER_MODEL"
+    )
+
+    catalog_count: int = Field(default=6, alias="CATALOG_COUNT", ge=1, le=12)
+    refresh_interval_seconds: int = Field(
+        default=43_200, alias="REFRESH_INTERVAL", ge=3_600
+    )
+    response_cache_seconds: int = Field(
+        default=1_800, alias="CACHE_TTL", ge=300
+    )
+
+    trakt_api_url: HttpUrl = Field(
+        default="https://api.trakt.tv", alias="TRAKT_API_URL"
+    )
+    openrouter_api_url: HttpUrl = Field(
+        default="https://openrouter.ai/api/v1", alias="OPENROUTER_API_URL"
+    )
+
+    environment: Literal["development", "production"] = Field(
+        default="development", alias="ENVIRONMENT"
+    )
+
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return a cached settings instance."""
+
+    return Settings()  # type: ignore[call-arg]
+
+
+settings = get_settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,138 @@
+"""Entry point for the FastAPI-powered Stremio addon."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+
+from .config import settings
+from .services.catalog_generator import CatalogService
+from .services.openrouter import OpenRouterClient
+from .services.trakt import TraktClient
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+app: FastAPI
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI):
+    exit_stack = AsyncExitStack()
+    trakt_client = await exit_stack.enter_async_context(
+        httpx.AsyncClient(
+            base_url=str(settings.trakt_api_url),
+            timeout=httpx.Timeout(20.0, connect=10.0),
+        )
+    )
+    openrouter_client = await exit_stack.enter_async_context(
+        httpx.AsyncClient(
+            base_url=str(settings.openrouter_api_url),
+            timeout=httpx.Timeout(60.0, connect=10.0),
+        )
+    )
+
+    trakt = TraktClient(settings, trakt_client)
+    openrouter = OpenRouterClient(settings, openrouter_client)
+    catalog_service = CatalogService(settings, trakt, openrouter)
+
+    app.state.catalog_service = catalog_service
+    await catalog_service.start()
+
+    try:
+        yield
+    finally:  # pragma: no cover - teardown path exercised at runtime
+        await catalog_service.stop()
+        await exit_stack.aclose()
+
+
+def create_app() -> FastAPI:
+    fastapi_app = FastAPI(
+        title=settings.app_name,
+        description="AI-personalized catalogs for Stremio powered by OpenRouter",
+        version="1.0.0",
+        lifespan=lifespan,
+    )
+
+    fastapi_app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_methods=["GET"],
+        allow_headers=["*"]
+    )
+
+    register_routes(fastapi_app)
+    return fastapi_app
+
+
+def get_catalog_service(app: FastAPI) -> CatalogService:
+    service = getattr(app.state, "catalog_service", None)
+    if not isinstance(service, CatalogService):
+        raise RuntimeError("Catalog service not initialised")
+    return service
+
+
+def register_routes(fastapi_app: FastAPI) -> None:
+    @fastapi_app.get("/healthz")
+    async def healthcheck() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @fastapi_app.get("/manifest.json")
+    async def manifest() -> dict[str, Any]:
+        service = get_catalog_service(fastapi_app)
+        catalogs = await service.list_manifest_catalogs()
+        return {
+            "id": "com.aiopicks.python",
+            "version": "1.0.0",
+            "name": f"{settings.app_name} (Gemini 2.5 Flash Lite)",
+            "description": (
+                "Dynamic, AI-randomized catalogs powered by OpenRouter's Google Gemini 2.5 "
+                "Flash Lite model and your Trakt history."
+            ),
+            "catalogs": catalogs,
+            "resources": ["catalog", "meta"],
+            "types": ["movie", "series"],
+            "idPrefixes": ["aiopicks", "tt", "trakt"],
+        }
+
+    @fastapi_app.get("/catalog/{content_type}/{catalog_id}.json")
+    async def catalog(content_type: str, catalog_id: str) -> JSONResponse:
+        if content_type not in {"movie", "series"}:
+            raise HTTPException(status_code=400, detail="Unsupported content type")
+        service = get_catalog_service(fastapi_app)
+        try:
+            payload = await service.get_catalog_payload(content_type, catalog_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return JSONResponse(payload)
+
+    @fastapi_app.get("/meta/{content_type}/{meta_id}.json")
+    async def meta(content_type: str, meta_id: str) -> JSONResponse:
+        if content_type not in {"movie", "series"}:
+            raise HTTPException(status_code=400, detail="Unsupported content type")
+        service = get_catalog_service(fastapi_app)
+        try:
+            meta_payload = await service.find_meta(content_type, meta_id)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return JSONResponse({"meta": meta_payload})
+
+
+app = create_app()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    import uvicorn
+
+    uvicorn.run(
+        "app.main:app",
+        host=settings.server_host,
+        port=settings.server_port,
+        reload=settings.environment == "development",
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,173 @@
+"""Pydantic models describing catalog payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, HttpUrl
+
+from .utils import ensure_unique_meta_id, slugify
+
+ContentType = Literal["movie", "series"]
+
+
+class CatalogItem(BaseModel):
+    """Represents a single media entry returned to Stremio."""
+
+    title: str = Field(alias="name")
+    type: ContentType
+    overview: str | None = Field(default=None, alias="description")
+    poster: HttpUrl | None = None
+    background: HttpUrl | None = None
+    year: int | None = None
+    trakt_id: int | None = None
+    imdb_id: str | None = None
+    tmdb_id: int | None = None
+    weight: float | None = None
+    runtime_minutes: int | None = None
+    genres: list[str] = Field(default_factory=list)
+    maturity_rating: str | None = None
+    providers: list[str] = Field(default_factory=list)
+
+    def to_meta(self, catalog_id: str, index: int) -> dict[str, object]:
+        """Return a Stremio meta dictionary."""
+
+        base_id = self.imdb_id or (f"trakt:{self.trakt_id}" if self.trakt_id else "")
+        meta_id = ensure_unique_meta_id(base_id, f"{catalog_id}-{self.title}", index)
+
+        meta: dict[str, object] = {
+            "id": meta_id,
+            "type": self.type,
+            "name": self.title,
+        }
+
+        if self.poster:
+            meta["poster"] = str(self.poster)
+        if self.background:
+            meta["background"] = str(self.background)
+        if self.overview:
+            meta["description"] = self.overview
+        if self.year:
+            meta["releaseInfo"] = str(self.year)
+        if self.weight is not None:
+            meta["aiConfidence"] = round(self.weight, 3)
+        if self.genres:
+            meta["genres"] = self.genres
+        if self.runtime_minutes:
+            meta["runtime"] = self.runtime_minutes
+        if self.maturity_rating:
+            meta["contentRating"] = self.maturity_rating
+        if self.providers:
+            meta["links"] = [
+                {"name": provider, "category": "where-to-watch"}
+                for provider in self.providers
+            ]
+
+        meta["behaviorHints"] = {
+            "bingeGroup": catalog_id,
+            "defaultVideoId": meta_id,
+        }
+        return meta
+
+
+class Catalog(BaseModel):
+    """Collection of items grouped by the AI."""
+
+    id: str
+    type: ContentType
+    title: str
+    description: str | None = None
+    seed: str | None = None
+    items: list[CatalogItem] = Field(default_factory=list)
+    generated_at: datetime
+
+    @classmethod
+    def from_ai_payload(
+        cls,
+        data: dict[str, object],
+        *,
+        content_type: ContentType,
+        fallback_seed: str,
+    ) -> "Catalog":
+        title = str(data.get("title") or data.get("name") or "Surprise Picks")
+        description = data.get("description") or data.get("summary")
+        seed = str(data.get("seed") or fallback_seed)
+        raw_items = data.get("items") or []
+        items: list[CatalogItem] = []
+
+        for entry in raw_items:
+            if not isinstance(entry, dict):
+                continue
+            item_data = {**entry}
+            item_data.setdefault("type", content_type)
+            item = CatalogItem.model_validate(item_data)
+            items.append(item)
+
+        catalog_id = str(data.get("id") or slugify(title))
+        catalog_slug = slugify(catalog_id)
+        if not catalog_slug:
+            catalog_slug = slugify(title)
+        final_id = f"aiopicks-{content_type}-{catalog_slug}"
+
+        return cls(
+            id=final_id,
+            type=content_type,
+            title=title,
+            description=str(description) if description else None,
+            seed=seed,
+            items=items,
+            generated_at=datetime.utcnow(),
+        )
+
+    def to_manifest_entry(self) -> dict[str, object]:
+        """Return a manifest catalog entry."""
+
+        return {
+            "type": self.type,
+            "id": self.id,
+            "name": self.title,
+            "extra": [],
+        }
+
+    def to_catalog_response(self) -> dict[str, object]:
+        """Return the Stremio catalog payload."""
+
+        metas = [item.to_meta(self.id, index) for index, item in enumerate(self.items)]
+        return {
+            "metas": metas,
+            "catalogName": self.title,
+            "catalogDescription": self.description,
+        }
+
+
+class CatalogBundle(BaseModel):
+    """A pair of movie and series catalogs returned by the AI."""
+
+    movie_catalogs: list[Catalog] = Field(default_factory=list)
+    series_catalogs: list[Catalog] = Field(default_factory=list)
+
+    @classmethod
+    def from_ai_response(
+        cls,
+        data: dict[str, object],
+        *,
+        seed: str,
+    ) -> "CatalogBundle":
+        movie_payload = data.get("movie_catalogs") or data.get("movies") or []
+        series_payload = data.get("series_catalogs") or data.get("shows") or []
+
+        movies = [
+            Catalog.from_ai_payload(entry, content_type="movie", fallback_seed=seed)
+            for entry in movie_payload
+            if isinstance(entry, dict)
+        ]
+        series = [
+            Catalog.from_ai_payload(entry, content_type="series", fallback_seed=seed)
+            for entry in series_payload
+            if isinstance(entry, dict)
+        ]
+        return cls(movie_catalogs=movies, series_catalogs=series)
+
+    def is_empty(self) -> bool:
+        return not (self.movie_catalogs or self.series_catalogs)

--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -1,0 +1,266 @@
+"""High level orchestration for catalog generation."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import secrets
+from contextlib import suppress
+from datetime import datetime, timedelta
+from typing import Any
+
+from pydantic import ValidationError
+
+from ..config import Settings
+from ..models import Catalog, CatalogBundle, CatalogItem
+from ..utils import slugify
+from .openrouter import OpenRouterClient
+from .trakt import TraktClient
+
+logger = logging.getLogger(__name__)
+
+
+class CatalogService:
+    """Coordinates Trakt ingestion with AI catalog generation."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        trakt_client: TraktClient,
+        openrouter_client: OpenRouterClient,
+    ):
+        self._settings = settings
+        self._trakt = trakt_client
+        self._ai = openrouter_client
+        self._catalogs: dict[str, dict[str, Catalog]] = {"movie": {}, "series": {}}
+        self._lock = asyncio.Lock()
+        self._last_refresh: datetime | None = None
+        self._refresh_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        """Initialise the service and launch the refresh loop."""
+
+        await self.ensure_catalogs(force=True)
+        if self._refresh_task is None:
+            self._refresh_task = asyncio.create_task(self._refresh_loop())
+
+    async def stop(self) -> None:
+        """Stop the background refresh loop."""
+
+        if self._refresh_task is None:
+            return
+        self._refresh_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await self._refresh_task
+        self._refresh_task = None
+
+    async def ensure_catalogs(self, *, force: bool = False) -> None:
+        """Refresh catalogs if the cache is stale."""
+
+        if not force and not self._should_refresh():
+            return
+
+        async with self._lock:
+            if not force and not self._should_refresh():
+                return
+            await self._refresh_catalogs()
+
+    async def _refresh_loop(self) -> None:
+        while True:
+            await asyncio.sleep(self._settings.refresh_interval_seconds)
+            try:
+                await self.ensure_catalogs(force=True)
+            except Exception as exc:  # pragma: no cover - background safety net
+                logger.exception("Scheduled refresh failed: %s", exc)
+
+    def _should_refresh(self) -> bool:
+        if self._last_refresh is None:
+            return True
+        expires_at = self._last_refresh + timedelta(seconds=self._settings.response_cache_seconds)
+        return datetime.utcnow() >= expires_at
+
+    async def _refresh_catalogs(self) -> None:
+        logger.info("Refreshing catalogs via OpenRouter model %s", self._settings.openrouter_model)
+
+        movie_history = await self._trakt.fetch_history("movies")
+        show_history = await self._trakt.fetch_history("shows")
+
+        summary = self._build_summary(movie_history, show_history)
+        seed = secrets.token_hex(4)
+
+        try:
+            bundle = await self._ai.generate_catalogs(summary, seed=seed)
+            catalogs = self._bundle_to_dict(bundle)
+            if catalogs["movie"] or catalogs["series"]:
+                self._catalogs = catalogs
+                self._last_refresh = datetime.utcnow()
+                logger.info(
+                    "Catalog refresh succeeded with %d movie and %d series catalogs",
+                    len(catalogs["movie"]),
+                    len(catalogs["series"]),
+                )
+                return
+            logger.warning("AI returned an empty catalog bundle, falling back to history data")
+        except Exception as exc:
+            logger.exception("AI generation failed, falling back to history data: %s", exc)
+
+        fallback = self._build_fallback_catalogs(movie_history, show_history, seed=seed)
+        self._catalogs = fallback
+        self._last_refresh = datetime.utcnow()
+
+    def _bundle_to_dict(self, bundle: CatalogBundle) -> dict[str, dict[str, Catalog]]:
+        return {
+            "movie": {catalog.id: catalog for catalog in bundle.movie_catalogs},
+            "series": {catalog.id: catalog for catalog in bundle.series_catalogs},
+        }
+
+    def _build_summary(
+        self,
+        movie_history: list[dict[str, Any]],
+        show_history: list[dict[str, Any]],
+    ) -> dict[str, Any]:
+        return {
+            "generated_at": datetime.utcnow().isoformat(),
+            "catalog_count": self._settings.catalog_count,
+            "profile": {
+                "movies": TraktClient.summarize_history(movie_history, key="movie"),
+                "series": TraktClient.summarize_history(show_history, key="show"),
+            },
+        }
+
+    def _build_fallback_catalogs(
+        self,
+        movie_history: list[dict[str, Any]],
+        show_history: list[dict[str, Any]],
+        *,
+        seed: str,
+    ) -> dict[str, dict[str, Catalog]]:
+        catalogs: dict[str, dict[str, Catalog]] = {"movie": {}, "series": {}}
+
+        if movie_history:
+            catalog = self._history_catalog(
+                movie_history,
+                content_type="movie",
+                title="AI Offline: Movies You Loved",
+                seed=seed,
+            )
+            catalogs["movie"][catalog.id] = catalog
+
+        if show_history:
+            catalog = self._history_catalog(
+                show_history,
+                content_type="series",
+                title="AI Offline: Series Marathon",
+                seed=seed,
+            )
+            catalogs["series"][catalog.id] = catalog
+
+        if not catalogs["movie"] and not catalogs["series"]:
+            now = datetime.utcnow()
+            stub_catalog = Catalog(
+                id=f"aiopicks-movie-stub-{seed}",
+                type="movie",
+                title="Connect Trakt to unlock personalized picks",
+                description="We need your Trakt API credentials to fetch history before calling the AI.",
+                seed=seed,
+                items=[],
+                generated_at=now,
+            )
+            catalogs["movie"][stub_catalog.id] = stub_catalog
+        return catalogs
+
+    def _history_catalog(
+        self,
+        history: list[dict[str, Any]],
+        *,
+        content_type: str,
+        title: str,
+        seed: str,
+    ) -> Catalog:
+        key = "movie" if content_type == "movie" else "show"
+        items: list[CatalogItem] = []
+        for index, entry in enumerate(history[:10]):
+            media = entry.get(key) or {}
+            if not isinstance(media, dict):
+                continue
+            ids = media.get("ids") or {}
+            data: dict[str, Any] = {
+                "name": media.get("title") or f"Unknown {content_type.title()}",
+                "type": content_type,
+                "description": media.get("overview") or entry.get("summary"),
+                "year": media.get("year"),
+                "imdb_id": ids.get("imdb"),
+                "trakt_id": ids.get("trakt"),
+                "tmdb_id": ids.get("tmdb"),
+                "runtime_minutes": media.get("runtime"),
+                "genres": [g for g in (media.get("genres") or []) if isinstance(g, str)],
+            }
+            poster = self._extract_image(media)
+            if poster:
+                data["poster"] = poster
+            background = self._extract_image(media, variant="fanart")
+            if background:
+                data["background"] = background
+
+            try:
+                item = CatalogItem.model_validate(data)
+            except ValidationError:
+                continue
+            items.append(item)
+
+        catalog_id = slugify(f"{title}-{seed[:6]}")
+        return Catalog(
+            id=f"aiopicks-{content_type}-{catalog_id}",
+            type=content_type,  # type: ignore[arg-type]
+            title=title,
+            description="Fallback catalog generated from your Trakt history.",
+            seed=seed,
+            items=items,
+            generated_at=datetime.utcnow(),
+        )
+
+    @staticmethod
+    def _extract_image(media: dict[str, Any], *, variant: str = "poster") -> str | None:
+        images = media.get("images")
+        if isinstance(images, dict):
+            variant_data = images.get(variant)
+            if isinstance(variant_data, dict):
+                for key in ("full", "medium", "thumb"):
+                    value = variant_data.get(key)
+                    if isinstance(value, str) and value.startswith("http"):
+                        return value
+        # fallback to direct fields some Trakt payloads expose
+        field = media.get(f"{variant}")
+        if isinstance(field, str) and field.startswith("http"):
+            return field
+        return None
+
+    async def list_manifest_catalogs(self) -> list[dict[str, object]]:
+        await self.ensure_catalogs()
+        entries: list[dict[str, object]] = []
+        for content_type in ("movie", "series"):
+            for catalog in self._catalogs.get(content_type, {}).values():
+                entries.append(catalog.to_manifest_entry())
+        return entries
+
+    async def get_catalog_payload(self, content_type: str, catalog_id: str) -> dict[str, object]:
+        await self.ensure_catalogs()
+        catalogs = self._catalogs.get(content_type)
+        if not catalogs:
+            raise KeyError(f"Unknown catalog type: {content_type}")
+        catalog = catalogs.get(catalog_id)
+        if not catalog:
+            raise KeyError(f"Catalog {catalog_id} not found")
+        return catalog.to_catalog_response()
+
+    async def find_meta(self, content_type: str, meta_id: str) -> dict[str, object]:
+        await self.ensure_catalogs()
+        catalogs = self._catalogs.get(content_type)
+        if not catalogs:
+            raise KeyError(f"Unknown catalog type: {content_type}")
+        for catalog in catalogs.values():
+            payload = catalog.to_catalog_response()
+            for meta in payload.get("metas", []):
+                if meta.get("id") == meta_id:
+                    return meta
+        raise KeyError(f"Meta {meta_id} not found in {content_type} catalogs")

--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -1,0 +1,144 @@
+"""Integration helpers for the OpenRouter API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+from ..config import Settings
+from ..models import CatalogBundle
+from ..utils import extract_json_object
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_PROMPT = (
+    "You are AIOPicks, an AI that curates playful but trustworthy movie and series catalogs "
+    "for the Stremio media center. You always respond with a single JSON object that matches "
+    "the documented schema and never include commentary outside JSON."
+)
+
+USER_PROMPT_TEMPLATE = """
+You are helping a power user discover new titles based on their Trakt history.
+
+Trakt profile summary (generated at {generated_at} UTC):
+- Total movies logged: {movie_total}
+- Total series logged: {series_total}
+- Movie taste snapshot: top genres {movie_genres}; top languages {movie_languages}
+- Series taste snapshot: top genres {series_genres}; top languages {series_languages}
+- Recently watched movies: {recent_movies}
+- Recently watched series: {recent_series}
+
+Instructions:
+1. Generate {catalog_count} movie catalogs AND {catalog_count} series catalogs.
+2. Use the random seed `{seed}` to introduce surprise (shuffle titles, invent novel themes).
+3. Each catalog must include 6-10 strong picks with real-world metadata.
+4. Avoid repeating catalog titles across refreshes by choosing unexpected phrasing.
+5. Balance comfort picks (known favorites) with 30% exploratory discoveries.
+6. Provide diverse posters/backgrounds when possible and include imdb or trakt IDs when you know them.
+
+Respond with JSON using this structure:
+{{
+  "movie_catalogs": [
+    {{
+      "id": "string",
+      "title": "string",
+      "description": "string",
+      "seed": "{seed}",
+      "items": [
+        {{
+          "name": "Movie title",
+          "type": "movie",
+          "description": "short synopsis",
+          "poster": "https://...",
+          "background": "https://...",
+          "year": 2024,
+          "imdb_id": "tt...",
+          "trakt_id": 12345,
+          "tmdb_id": 67890,
+          "runtime_minutes": 120,
+          "genres": ["genre"],
+          "maturity_rating": "PG-13",
+          "weight": 0.0,
+          "providers": ["Netflix", "Hulu"]
+        }}
+      ]
+    }}
+  ],
+  "series_catalogs": [
+    {{ ... same fields but type "series" ... }}
+  ]
+}}
+"""
+
+
+class OpenRouterClient:
+    """Client responsible for talking to OpenRouter."""
+
+    def __init__(self, settings: Settings, http_client: httpx.AsyncClient):
+        self._settings = settings
+        self._client = http_client
+
+    async def generate_catalogs(
+        self,
+        summary: dict[str, Any],
+        *,
+        seed: str,
+    ) -> CatalogBundle:
+        """Generate new catalogs using the configured model."""
+
+        catalog_count = summary.get("catalog_count", self._settings.catalog_count)
+        profile = summary.get("profile", {})
+
+        prompt = USER_PROMPT_TEMPLATE.format(
+            generated_at=summary.get("generated_at"),
+            movie_total=profile.get("movies", {}).get("total"),
+            series_total=profile.get("series", {}).get("total"),
+            movie_genres=profile.get("movies", {}).get("top_genres"),
+            series_genres=profile.get("series", {}).get("top_genres"),
+            movie_languages=profile.get("movies", {}).get("top_languages"),
+            series_languages=profile.get("series", {}).get("top_languages"),
+            recent_movies=profile.get("movies", {}).get("top_titles"),
+            recent_series=profile.get("series", {}).get("top_titles"),
+            catalog_count=catalog_count,
+            seed=seed,
+        )
+
+        payload = {
+            "model": self._settings.openrouter_model,
+            "temperature": 1.1,
+            "top_p": 0.9,
+            "max_output_tokens": 2_500,
+            "messages": [
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": prompt},
+            ],
+        }
+
+        headers = {
+            "Authorization": f"Bearer {self._settings.openrouter_api_key}",
+            "Content-Type": "application/json",
+            "HTTP-Referer": "https://github.com/aiopicks/aiopicks",
+            "X-Title": "AIOPicks Python",
+        }
+
+        response = await self._client.post("/chat/completions", json=payload, headers=headers)
+        if response.status_code >= 400:
+            logger.error("OpenRouter request failed: %s", response.text)
+            raise RuntimeError("OpenRouter request failed")
+
+        data = response.json()
+        choices = data.get("choices", [])
+        if not choices:
+            raise RuntimeError("Model returned no choices")
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if not isinstance(content, str):
+            raise RuntimeError("Model response missing content")
+
+        parsed = extract_json_object(content)
+        bundle = CatalogBundle.from_ai_response(parsed, seed=seed)
+        if bundle.is_empty():
+            raise RuntimeError("Model returned an empty catalog bundle")
+        return bundle

--- a/app/services/trakt.py
+++ b/app/services/trakt.py
@@ -1,0 +1,103 @@
+"""Utilities for communicating with the Trakt API."""
+
+from __future__ import annotations
+
+import logging
+from collections import Counter
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from ..config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+class TraktClient:
+    """Thin wrapper around the Trakt HTTP API."""
+
+    def __init__(self, settings: Settings, http_client: httpx.AsyncClient):
+        self._settings = settings
+        self._client = http_client
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "trakt-api-version": "2",
+        }
+        if self._settings.trakt_client_id:
+            headers["trakt-api-key"] = self._settings.trakt_client_id
+        if self._settings.trakt_access_token:
+            headers["Authorization"] = f"Bearer {self._settings.trakt_access_token}"
+        return headers
+
+    async def fetch_history(self, content_type: str) -> list[dict[str, Any]]:
+        """Fetch the user's viewing history."""
+
+        if not (self._settings.trakt_client_id and self._settings.trakt_access_token):
+            logger.info("Trakt credentials missing, returning empty history for %s", content_type)
+            return []
+
+        url = f"/sync/history/{content_type}"
+        params = {
+            "limit": self._settings.trakt_history_limit,
+            "extended": "full",
+        }
+        response = await self._client.get(url, headers=self._headers(), params=params)
+        if response.status_code >= 400:
+            logger.warning("Failed to fetch Trakt history for %s: %s", content_type, response.text)
+            return []
+        data = response.json()
+        if not isinstance(data, list):
+            logger.warning("Unexpected Trakt response structure for %s", content_type)
+            return []
+        return data
+
+    @staticmethod
+    def summarize_history(history: list[dict[str, Any]], *, key: str) -> dict[str, Any]:
+        """Summarize a history dataset for the language model."""
+
+        genres: Counter[str] = Counter()
+        countries: Counter[str] = Counter()
+        languages: Counter[str] = Counter()
+        runtimes: list[int] = []
+        titles: list[str] = []
+        latest_watch: datetime | None = None
+
+        for entry in history:
+            media = entry.get(key) or {}
+            if not isinstance(media, dict):
+                continue
+            title = media.get("title")
+            if isinstance(title, str):
+                titles.append(title)
+            genres.update(g for g in (media.get("genres") or []) if isinstance(g, str))
+            countries.update(c for c in (media.get("country") or []) if isinstance(c, str))
+            language = media.get("language")
+            if isinstance(language, str):
+                languages.update([language])
+            runtime = media.get("runtime")
+            if isinstance(runtime, int):
+                runtimes.append(runtime)
+
+            watched_at = entry.get("watched_at")
+            if isinstance(watched_at, str):
+                try:
+                    parsed = datetime.fromisoformat(watched_at.replace("Z", "+00:00"))
+                except ValueError:
+                    parsed = None
+                if parsed and (latest_watch is None or parsed > latest_watch):
+                    latest_watch = parsed
+
+        def top_values(counter: Counter[str]) -> list[tuple[str, int]]:
+            return counter.most_common(5)
+
+        return {
+            "total": len(history),
+            "top_titles": titles[:20],
+            "top_genres": top_values(genres),
+            "top_countries": top_values(countries),
+            "top_languages": top_values(languages),
+            "average_runtime": sum(runtimes) // len(runtimes) if runtimes else None,
+            "last_watched_at": latest_watch.isoformat() if latest_watch else None,
+        }

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,0 +1,52 @@
+"""Utility helpers for the AIOPicks service."""
+
+from __future__ import annotations
+
+import json
+import re
+import unicodedata
+from typing import Any
+
+
+JSON_BLOCK_RE = re.compile(r"```(?:json)?\s*(\{.*?\})\s*```", re.DOTALL)
+BARE_JSON_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
+def slugify(value: str) -> str:
+    """Return a URL-friendly slug."""
+
+    value = unicodedata.normalize("NFKD", value)
+    value = value.encode("ascii", "ignore").decode("ascii")
+    value = re.sub(r"[^a-zA-Z0-9]+", "-", value)
+    value = value.strip("-")
+    value = re.sub(r"-+", "-", value)
+    return value.lower() or "catalog"
+
+
+def extract_json_object(content: str) -> dict[str, Any]:
+    """Extract and parse the first JSON object from the model response."""
+
+    match = JSON_BLOCK_RE.search(content)
+    if match:
+        payload = match.group(1)
+    else:
+        match = BARE_JSON_RE.search(content)
+        if not match:
+            raise ValueError("No JSON object found in response")
+        payload = match.group(0)
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive branch
+        raise ValueError("Invalid JSON payload produced by the model") from exc
+
+
+def ensure_unique_meta_id(base_id: str, fallback: str, index: int) -> str:
+    """Generate a deterministic unique meta identifier."""
+
+    if base_id:
+        return base_id
+    slug = slugify(fallback)
+    if not slug:
+        slug = "meta"
+    return f"{slug}-{index}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  aiopicks:
+    build: .
+    image: aiopicks:latest
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    restart: unless-stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ include = ["app*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = "."
 filterwarnings = [
     "ignore::DeprecationWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "aiopicks"
+version = "0.1.0"
+description = "AI-personalized Stremio catalogs powered by OpenRouter and Trakt"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "AIOPicks" }]
+dependencies = [
+    "fastapi>=0.110,<0.113",
+    "uvicorn[standard]>=0.29,<0.32",
+    "httpx>=0.27,<0.28",
+    "pydantic>=2.7,<3",
+    "pydantic-settings>=2.2,<3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.2,<9",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["app*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ include = ["app*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+# Ensure the repository root is on sys.path so tests can import the FastAPI app package.
 pythonpath = "."
 filterwarnings = [
     "ignore::DeprecationWarning",

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,49 @@
+from app.models import Catalog, CatalogBundle
+
+
+def test_catalog_from_ai_payload_generates_ids():
+    catalog = Catalog.from_ai_payload(
+        {
+            "title": "Cozy Time Capsules",
+            "description": "Stories to unwind with",
+            "items": [
+                {
+                    "name": "The Secret Life of Walter Mitty",
+                    "type": "movie",
+                    "description": "A daydreamer's journey",
+                    "poster": "https://example.com/poster.jpg",
+                    "year": 2013,
+                    "imdb_id": "tt0359950",
+                }
+            ],
+        },
+        content_type="movie",
+        fallback_seed="abcd",
+    )
+
+    assert catalog.id.startswith("aiopicks-movie")
+    assert catalog.items[0].to_meta(catalog.id, 0)["id"] == "tt0359950"
+
+
+def test_catalog_bundle_from_ai_response_handles_missing_sections():
+    bundle = CatalogBundle.from_ai_response(
+        {
+            "movies": [
+                {
+                    "title": "Chill Friday",
+                    "items": [
+                        {
+                            "name": "Arrival",
+                            "type": "movie",
+                            "poster": "https://example.com/arrival.jpg",
+                        }
+                    ],
+                }
+            ]
+        },
+        seed="abcd",
+    )
+
+    assert len(bundle.movie_catalogs) == 1
+    assert bundle.movie_catalogs[0].title == "Chill Friday"
+    assert bundle.series_catalogs == []

--- a/tests/test_repository_integrity.py
+++ b/tests/test_repository_integrity.py
@@ -1,0 +1,35 @@
+"""Repository-level integrity checks."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+CONFLICT_PATTERN = re.compile(r"^(<<<<<<<|=======|>>>>>>>)", re.MULTILINE)
+IGNORED_PARTS = {".git", "__pycache__", ".mypy_cache", ".pytest_cache", ".venv"}
+
+
+def test_repository_has_no_merge_conflict_markers() -> None:
+    """Ensure no files in the repo still contain git conflict markers."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    offending_files: list[Path] = []
+
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if any(part in IGNORED_PARTS for part in path.parts):
+            continue
+
+        try:
+            contents = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            contents = path.read_text(encoding="utf-8", errors="ignore")
+
+        if CONFLICT_PATTERN.search(contents):
+            offending_files.append(path.relative_to(repo_root))
+
+    assert not offending_files, (
+        "The following files still contain git conflict markers: "
+        + ", ".join(str(path) for path in offending_files)
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+from app.utils import ensure_unique_meta_id, extract_json_object, slugify
+
+
+def test_slugify_basic():
+    assert slugify("Late Night Thrills!") == "late-night-thrills"
+
+
+def test_extract_json_object_from_markdown():
+    payload = """
+    Here is your payload:
+    ```json
+    {"movie_catalogs": []}
+    ```
+    """
+    assert extract_json_object(payload) == {"movie_catalogs": []}
+
+
+def test_ensure_unique_meta_id_with_fallback():
+    meta_id = ensure_unique_meta_id("", "Some Title", 3)
+    assert meta_id.startswith("some-title")


### PR DESCRIPTION
## Summary
- add a FastAPI-powered Stremio addon that calls OpenRouter's google/gemini-2.5-flash-lite model for randomized catalogs
- integrate Trakt history ingestion, AI prompting, caching, and graceful fallbacks when the model is unavailable
- introduce Python project scaffolding, Dockerfile, environment template, and unit tests for key helpers
- document Docker Compose deployment and ship a ready-to-run compose file for self-hosting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c9ec8537088322b99e8b792ff9f65c