### PR TITLE
Add Docker Compose configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,21 @@ pytest
 
 ## 🐳 Docker Quickstart
 
+### Using Docker Compose (recommended)
+
+```bash
+cp .env.sample .env  # then edit with your keys
+docker compose up -d --build
+```
+
+This command builds the image, starts the `aiopicks` service, and automatically loads
+environment variables from `.env`. Visit
+`http://localhost:3000/manifest.json` to verify the addon is running. Tail
+logs with `docker compose logs -f aiopicks` and stop the stack when you are
+finished with `docker compose down`.
+
+### Manual Docker commands
+
 ```bash
 docker build -t aiopicks .
 docker run -d \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  aiopicks:
+    build:
+      context: .
+    image: aiopicks:latest
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    environment:
+      - ENVIRONMENT=production
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add a Docker Compose definition for running the aiopicks service with production defaults
- document the Docker Compose workflow and keep the existing manual Docker commands

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68c9f98f844c8322b4e0a0572a956f78