### PR TITLE
Add persistent profile storage and refresh orchestration

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
         default="https://openrouter.ai/api/v1", alias="OPENROUTER_API_URL"
     )
 
+    database_url: str = Field(
+        default="sqlite+aiosqlite:///./aiopicks.db", alias="DATABASE_URL"
+    )
+
     environment: Literal["development", "production"] = Field(
         default="development", alias="ENVIRONMENT"
     )

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,53 @@
+"""Database utilities for the AIOPicks service."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from sqlalchemy import MetaData
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Declarative base with consistent naming conventions."""
+
+    metadata = MetaData()
+
+
+class Database:
+    """Thin wrapper managing the SQLAlchemy async engine and sessions."""
+
+    def __init__(self, database_url: str):
+        self._engine: AsyncEngine = create_async_engine(database_url, future=True)
+        self.session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
+            self._engine, expire_on_commit=False
+        )
+
+    @property
+    def engine(self) -> AsyncEngine:
+        return self._engine
+
+    async def create_all(self) -> None:
+        """Create database tables if they do not yet exist."""
+
+        async with self._engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all)
+
+    async def dispose(self) -> None:
+        """Dispose of the underlying database engine."""
+
+        await self._engine.dispose()
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[AsyncSession]:
+        """Provide a transactional scope around a series of operations."""
+
+        async with self.session_factory() as session:
+            yield session

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -1,0 +1,69 @@
+"""SQLAlchemy ORM models backing the persistent state."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class Profile(Base):
+    """Represents a persisted user configuration profile."""
+
+    __tablename__ = "profiles"
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    display_name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    openrouter_api_key: Mapped[str] = mapped_column(Text)
+    openrouter_model: Mapped[str] = mapped_column(String(200))
+    trakt_client_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    trakt_access_token: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    catalog_count: Mapped[int] = mapped_column(Integer, default=6)
+    refresh_interval_seconds: Mapped[int] = mapped_column(Integer, default=43_200)
+    response_cache_seconds: Mapped[int] = mapped_column(Integer, default=1_800)
+    next_refresh_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_refreshed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    catalogs: Mapped[list["CatalogRecord"]] = relationship(
+        back_populates="profile", cascade="all, delete-orphan"
+    )
+
+
+class CatalogRecord(Base):
+    """Persisted catalog payloads tied to a profile."""
+
+    __tablename__ = "catalogs"
+    __table_args__ = (
+        UniqueConstraint("profile_id", "catalog_id", name="uq_catalog_profile"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("profiles.id", ondelete="CASCADE")
+    )
+    content_type: Mapped[str] = mapped_column(String(16))
+    catalog_id: Mapped[str] = mapped_column(String(255))
+    title: Mapped[str] = mapped_column(String(255))
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    seed: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    position: Mapped[int] = mapped_column(Integer, default=0)
+    payload: Mapped[dict[str, object]] = mapped_column(JSON)
+    generated_at: Mapped[datetime] = mapped_column(DateTime)
+    expires_at: Mapped[datetime] = mapped_column(DateTime)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    profile: Mapped[Profile] = relationship(back_populates="catalogs")

--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -3,21 +3,124 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import secrets
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Mapping
 
-from pydantic import ValidationError
+from pydantic import AliasChoices, BaseModel, Field, ValidationError, field_validator
+from sqlalchemy import delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from ..config import Settings
+from ..db_models import CatalogRecord, Profile
 from ..models import Catalog, CatalogBundle, CatalogItem
 from ..utils import slugify
 from .openrouter import OpenRouterClient
 from .trakt import TraktClient
 
 logger = logging.getLogger(__name__)
+
+
+class ManifestConfig(BaseModel):
+    """Normalized view of query parameters controlling profile selection."""
+
+    profile_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("profile", "profileId"),
+    )
+    openrouter_key: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("openrouterKey", "openRouterKey"),
+    )
+    openrouter_model: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("openrouterModel", "openRouterModel"),
+    )
+    catalog_count: int | None = Field(
+        default=None,
+        ge=1,
+        le=12,
+        validation_alias=AliasChoices("catalogCount", "count"),
+    )
+    refresh_interval: int | None = Field(
+        default=None,
+        ge=3_600,
+        validation_alias=AliasChoices("refreshInterval", "refreshSeconds"),
+    )
+    response_cache: int | None = Field(
+        default=None,
+        ge=300,
+        validation_alias=AliasChoices("cacheTtl", "cacheTTL", "cacheSeconds"),
+    )
+    trakt_client_id: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("traktClientId", "traktClientID"),
+    )
+    trakt_access_token: str | None = Field(
+        default=None,
+        validation_alias=AliasChoices("traktAccessToken", "traktToken"),
+    )
+
+    @classmethod
+    def from_query(cls, params: Mapping[str, str]) -> "ManifestConfig":
+        return cls.model_validate(dict(params))
+
+    @field_validator("catalog_count", "refresh_interval", "response_cache", mode="before")
+    @classmethod
+    def _parse_optional_int(cls, value: object) -> object:
+        if value is None or value == "":
+            return None
+        if isinstance(value, int):
+            return value
+        try:
+            return int(str(value))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("Value must be an integer") from exc
+
+    @field_validator(
+        "profile_id",
+        "openrouter_key",
+        "openrouter_model",
+        "trakt_client_id",
+        "trakt_access_token",
+        mode="before",
+    )
+    @classmethod
+    def _strip_blank(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            stripped = value.strip()
+            return stripped or None
+        return value
+
+
+@dataclass
+class ProfileState:
+    """Snapshot of a stored profile used for runtime decisions."""
+
+    id: str
+    openrouter_api_key: str
+    openrouter_model: str
+    trakt_client_id: str | None
+    trakt_access_token: str | None
+    catalog_count: int
+    refresh_interval_seconds: int
+    response_cache_seconds: int
+    next_refresh_at: datetime | None
+    last_refreshed_at: datetime | None
+
+
+@dataclass
+class ProfileContext:
+    """Resolved profile along with whether a refresh is required."""
+
+    state: ProfileState
+    force_refresh: bool = False
 
 
 class CatalogService:
@@ -28,19 +131,23 @@ class CatalogService:
         settings: Settings,
         trakt_client: TraktClient,
         openrouter_client: OpenRouterClient,
+        session_factory: async_sessionmaker[AsyncSession],
     ):
         self._settings = settings
         self._trakt = trakt_client
         self._ai = openrouter_client
-        self._catalogs: dict[str, dict[str, Catalog]] = {"movie": {}, "series": {}}
-        self._lock = asyncio.Lock()
-        self._last_refresh: datetime | None = None
+        self._session_factory = session_factory
+        self._locks: dict[str, asyncio.Lock] = {}
         self._refresh_task: asyncio.Task[None] | None = None
+        self._refresh_poll_seconds = 60
 
     async def start(self) -> None:
         """Initialise the service and launch the refresh loop."""
 
-        await self.ensure_catalogs(force=True)
+        await self._ensure_default_profile()
+        default_state = await self._load_profile_state("default")
+        if default_state:
+            await self.ensure_catalogs(default_state, force=True)
         if self._refresh_task is None:
             self._refresh_task = asyncio.create_task(self._refresh_loop())
 
@@ -54,59 +161,359 @@ class CatalogService:
             await self._refresh_task
         self._refresh_task = None
 
-    async def ensure_catalogs(self, *, force: bool = False) -> None:
-        """Refresh catalogs if the cache is stale."""
+    async def list_manifest_catalogs(
+        self, config: ManifestConfig
+    ) -> tuple[ProfileState, list[dict[str, Any]]]:
+        """Return manifest catalog entries for the resolved profile."""
 
-        if not force and not self._should_refresh():
-            return
+        state = await self.prepare_profile(config)
+        catalogs = await self._load_catalogs(state.id)
+        grouped: dict[str, list[Catalog]] = {"movie": [], "series": []}
+        for catalog in catalogs:
+            grouped.setdefault(catalog.type, []).append(catalog)
+        manifest_entries: list[dict[str, Any]] = []
+        for content_type in ("movie", "series"):
+            for catalog in grouped.get(content_type, []):
+                manifest_entries.append(catalog.to_manifest_entry())
+        return state, manifest_entries
 
-        async with self._lock:
-            if not force and not self._should_refresh():
-                return
-            await self._refresh_catalogs()
+    async def get_catalog_payload(
+        self,
+        config: ManifestConfig,
+        content_type: str,
+        catalog_id: str,
+    ) -> dict[str, Any]:
+        """Return the catalog payload for a profile/content combination."""
+
+        state = await self.prepare_profile(config)
+        catalog = await self._load_single_catalog(state.id, content_type, catalog_id)
+        if catalog is None:
+            raise KeyError(f"Catalog {catalog_id} not found for profile {state.id}")
+        return catalog.to_catalog_response()
+
+    async def find_meta(
+        self,
+        config: ManifestConfig,
+        content_type: str,
+        meta_id: str,
+    ) -> dict[str, Any]:
+        """Locate a specific meta entry within the stored catalogs."""
+
+        state = await self.prepare_profile(config)
+        catalogs = await self._load_catalogs(state.id, content_type=content_type)
+        for catalog in catalogs:
+            for index, item in enumerate(catalog.items):
+                meta = item.to_meta(catalog.id, index)
+                if meta["id"] == meta_id:
+                    return meta
+        raise KeyError(f"Meta {meta_id} not found for profile {state.id}")
+
+    async def prepare_profile(self, config: ManifestConfig) -> ProfileState:
+        """Resolve the profile, ensure catalogs are current, and return its state."""
+
+        context = await self._resolve_profile(config)
+        return await self.ensure_catalogs(context.state, force=context.force_refresh)
+
+    async def ensure_catalogs(
+        self, state: ProfileState, *, force: bool = False
+    ) -> ProfileState:
+        """Refresh catalogs for the profile if the cache is stale."""
+
+        lock = self._locks.setdefault(state.id, asyncio.Lock())
+        async with lock:
+            latest_state = await self._load_profile_state(state.id) or state
+            needs_refresh = force or await self._needs_refresh(latest_state)
+            if not needs_refresh:
+                return latest_state
+            await self._refresh_catalogs(latest_state)
+            refreshed_state = await self._load_profile_state(state.id)
+            return refreshed_state or latest_state
 
     async def _refresh_loop(self) -> None:
         while True:
-            await asyncio.sleep(self._settings.refresh_interval_seconds)
+            await asyncio.sleep(self._refresh_poll_seconds)
             try:
-                await self.ensure_catalogs(force=True)
+                await self._refresh_due_profiles()
             except Exception as exc:  # pragma: no cover - background safety net
                 logger.exception("Scheduled refresh failed: %s", exc)
 
-    def _should_refresh(self) -> bool:
-        if self._last_refresh is None:
+    async def _refresh_due_profiles(self) -> None:
+        now = datetime.utcnow()
+        async with self._session_factory() as session:
+            stmt = select(Profile.id).where(
+                Profile.next_refresh_at.is_not(None),
+                Profile.next_refresh_at <= now,
+            )
+            result = await session.execute(stmt)
+            profile_ids = [row[0] for row in result.all()]
+
+        for profile_id in profile_ids:
+            state = await self._load_profile_state(profile_id)
+            if state is None:
+                continue
+            await self.ensure_catalogs(state, force=True)
+
+    async def _needs_refresh(self, state: ProfileState) -> bool:
+        if state.last_refreshed_at is None:
             return True
-        expires_at = self._last_refresh + timedelta(seconds=self._settings.response_cache_seconds)
+        if not await self._has_catalogs(state.id):
+            return True
+        expires_at = state.last_refreshed_at + timedelta(
+            seconds=state.response_cache_seconds
+        )
         return datetime.utcnow() >= expires_at
 
-    async def _refresh_catalogs(self) -> None:
-        logger.info("Refreshing catalogs via OpenRouter model %s", self._settings.openrouter_model)
+    async def _has_catalogs(self, profile_id: str) -> bool:
+        async with self._session_factory() as session:
+            stmt = (
+                select(CatalogRecord.id)
+                .where(CatalogRecord.profile_id == profile_id)
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            return result.scalar_one_or_none() is not None
 
-        movie_history = await self._trakt.fetch_history("movies")
-        show_history = await self._trakt.fetch_history("shows")
+    async def _refresh_catalogs(self, state: ProfileState) -> None:
+        logger.info(
+            "Refreshing catalogs for profile %s via model %s",
+            state.id,
+            state.openrouter_model,
+        )
 
-        summary = self._build_summary(movie_history, show_history)
+        movie_history = await self._trakt.fetch_history(
+            "movies",
+            client_id=state.trakt_client_id,
+            access_token=state.trakt_access_token,
+        )
+        show_history = await self._trakt.fetch_history(
+            "shows",
+            client_id=state.trakt_client_id,
+            access_token=state.trakt_access_token,
+        )
+
+        summary = self._build_summary(
+            movie_history,
+            show_history,
+            catalog_count=state.catalog_count,
+        )
         seed = secrets.token_hex(4)
+        catalogs: dict[str, dict[str, Catalog]] | None = None
 
         try:
-            bundle = await self._ai.generate_catalogs(summary, seed=seed)
+            bundle = await self._ai.generate_catalogs(
+                summary,
+                seed=seed,
+                api_key=state.openrouter_api_key,
+                model=state.openrouter_model,
+            )
             catalogs = self._bundle_to_dict(bundle)
-            if catalogs["movie"] or catalogs["series"]:
-                self._catalogs = catalogs
-                self._last_refresh = datetime.utcnow()
-                logger.info(
-                    "Catalog refresh succeeded with %d movie and %d series catalogs",
-                    len(catalogs["movie"]),
-                    len(catalogs["series"]),
+            if not (catalogs["movie"] or catalogs["series"]):
+                logger.warning(
+                    "AI returned an empty catalog bundle for profile %s; falling back to history",
+                    state.id,
                 )
-                return
-            logger.warning("AI returned an empty catalog bundle, falling back to history data")
+                catalogs = None
         except Exception as exc:
-            logger.exception("AI generation failed, falling back to history data: %s", exc)
+            logger.exception(
+                "AI generation failed for profile %s, falling back to history data: %s",
+                state.id,
+                exc,
+            )
+            catalogs = None
 
-        fallback = self._build_fallback_catalogs(movie_history, show_history, seed=seed)
-        self._catalogs = fallback
-        self._last_refresh = datetime.utcnow()
+        if catalogs is None:
+            catalogs = self._build_fallback_catalogs(
+                movie_history, show_history, seed=seed
+            )
+
+        await self._store_catalogs(state, catalogs)
+
+    async def _store_catalogs(
+        self,
+        state: ProfileState,
+        catalogs: dict[str, dict[str, Catalog]],
+    ) -> None:
+        now = datetime.utcnow()
+        async with self._session_factory() as session:
+            await session.execute(
+                delete(CatalogRecord).where(CatalogRecord.profile_id == state.id)
+            )
+            for content_type, catalog_map in catalogs.items():
+                for position, catalog in enumerate(catalog_map.values()):
+                    payload = catalog.model_dump(mode="json")
+                    expires_at = catalog.generated_at + timedelta(
+                        seconds=state.response_cache_seconds
+                    )
+                    record = CatalogRecord(
+                        profile_id=state.id,
+                        content_type=content_type,
+                        catalog_id=catalog.id,
+                        title=catalog.title,
+                        description=catalog.description,
+                        seed=catalog.seed,
+                        position=position,
+                        payload=payload,
+                        generated_at=catalog.generated_at,
+                        expires_at=expires_at,
+                        created_at=now,
+                        updated_at=now,
+                    )
+                    session.add(record)
+            next_refresh = now + timedelta(seconds=state.refresh_interval_seconds)
+            await session.execute(
+                update(Profile)
+                .where(Profile.id == state.id)
+                .values(
+                    last_refreshed_at=now,
+                    next_refresh_at=next_refresh,
+                    updated_at=now,
+                )
+            )
+            await session.commit()
+
+    async def _load_profile_state(self, profile_id: str) -> ProfileState | None:
+        async with self._session_factory() as session:
+            profile = await session.get(Profile, profile_id)
+            if profile is None:
+                return None
+            return self._profile_to_state(profile)
+
+    def _profile_to_state(self, profile: Profile) -> ProfileState:
+        return ProfileState(
+            id=profile.id,
+            openrouter_api_key=profile.openrouter_api_key,
+            openrouter_model=profile.openrouter_model,
+            trakt_client_id=profile.trakt_client_id,
+            trakt_access_token=profile.trakt_access_token,
+            catalog_count=profile.catalog_count,
+            refresh_interval_seconds=profile.refresh_interval_seconds,
+            response_cache_seconds=profile.response_cache_seconds,
+            next_refresh_at=profile.next_refresh_at,
+            last_refreshed_at=profile.last_refreshed_at,
+        )
+
+    async def _resolve_profile(self, config: ManifestConfig) -> ProfileContext:
+        profile_id = self._determine_profile_id(config)
+        async with self._session_factory() as session:
+            profile = await session.get(Profile, profile_id)
+            created = False
+            refresh_required = False
+            now = datetime.utcnow()
+
+            if profile is None:
+                openrouter_key = config.openrouter_key or self._settings.openrouter_api_key
+                if not openrouter_key:
+                    raise ValueError("An OpenRouter API key is required.")
+                profile = Profile(
+                    id=profile_id,
+                    openrouter_api_key=openrouter_key,
+                    openrouter_model=config.openrouter_model or self._settings.openrouter_model,
+                    catalog_count=config.catalog_count or self._settings.catalog_count,
+                    refresh_interval_seconds=config.refresh_interval or self._settings.refresh_interval_seconds,
+                    response_cache_seconds=config.response_cache or self._settings.response_cache_seconds,
+                    trakt_client_id=config.trakt_client_id or self._settings.trakt_client_id,
+                    trakt_access_token=config.trakt_access_token or self._settings.trakt_access_token,
+                    next_refresh_at=now,
+                    last_refreshed_at=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+                session.add(profile)
+                created = True
+                refresh_required = True
+            else:
+                if config.openrouter_key and config.openrouter_key != profile.openrouter_api_key:
+                    profile.openrouter_api_key = config.openrouter_key
+                    refresh_required = True
+                if config.openrouter_model and config.openrouter_model != profile.openrouter_model:
+                    profile.openrouter_model = config.openrouter_model
+                    refresh_required = True
+                if config.catalog_count and config.catalog_count != profile.catalog_count:
+                    profile.catalog_count = config.catalog_count
+                    refresh_required = True
+                if config.refresh_interval and config.refresh_interval != profile.refresh_interval_seconds:
+                    profile.refresh_interval_seconds = config.refresh_interval
+                if config.response_cache and config.response_cache != profile.response_cache_seconds:
+                    profile.response_cache_seconds = config.response_cache
+                if config.trakt_client_id is not None and config.trakt_client_id != profile.trakt_client_id:
+                    profile.trakt_client_id = config.trakt_client_id
+                    refresh_required = True
+                if config.trakt_access_token is not None and config.trakt_access_token != profile.trakt_access_token:
+                    profile.trakt_access_token = config.trakt_access_token
+                    refresh_required = True
+                if profile.next_refresh_at is None:
+                    profile.next_refresh_at = now
+                profile.updated_at = now
+
+            await session.commit()
+            await session.refresh(profile)
+            state = self._profile_to_state(profile)
+
+        return ProfileContext(state=state, force_refresh=refresh_required or created)
+
+    def _determine_profile_id(self, config: ManifestConfig) -> str:
+        if config.profile_id:
+            slug = slugify(config.profile_id)
+            if slug:
+                return slug
+        if config.openrouter_key:
+            digest = hashlib.sha256(config.openrouter_key.encode("utf-8")).hexdigest()[:12]
+            return f"user-{digest}"
+        return "default"
+
+    async def _ensure_default_profile(self) -> None:
+        async with self._session_factory() as session:
+            profile = await session.get(Profile, "default")
+            now = datetime.utcnow()
+            if profile is None:
+                if not self._settings.openrouter_api_key:
+                    raise RuntimeError(
+                        "OPENROUTER_API_KEY must be configured for the default profile"
+                    )
+                profile = Profile(
+                    id="default",
+                    openrouter_api_key=self._settings.openrouter_api_key,
+                    openrouter_model=self._settings.openrouter_model,
+                    trakt_client_id=self._settings.trakt_client_id,
+                    trakt_access_token=self._settings.trakt_access_token,
+                    catalog_count=self._settings.catalog_count,
+                    refresh_interval_seconds=self._settings.refresh_interval_seconds,
+                    response_cache_seconds=self._settings.response_cache_seconds,
+                    next_refresh_at=now,
+                    last_refreshed_at=None,
+                    created_at=now,
+                    updated_at=now,
+                )
+                session.add(profile)
+            else:
+                updated = False
+                if not profile.openrouter_api_key and self._settings.openrouter_api_key:
+                    profile.openrouter_api_key = self._settings.openrouter_api_key
+                    updated = True
+                if not profile.openrouter_model:
+                    profile.openrouter_model = self._settings.openrouter_model
+                    updated = True
+                if profile.catalog_count != self._settings.catalog_count:
+                    profile.catalog_count = self._settings.catalog_count
+                    updated = True
+                if profile.refresh_interval_seconds != self._settings.refresh_interval_seconds:
+                    profile.refresh_interval_seconds = self._settings.refresh_interval_seconds
+                    updated = True
+                if profile.response_cache_seconds != self._settings.response_cache_seconds:
+                    profile.response_cache_seconds = self._settings.response_cache_seconds
+                    updated = True
+                if profile.trakt_client_id != self._settings.trakt_client_id:
+                    profile.trakt_client_id = self._settings.trakt_client_id
+                    updated = True
+                if profile.trakt_access_token != self._settings.trakt_access_token:
+                    profile.trakt_access_token = self._settings.trakt_access_token
+                    updated = True
+                if profile.next_refresh_at is None:
+                    profile.next_refresh_at = now
+                    updated = True
+                if updated:
+                    profile.updated_at = now
+            await session.commit()
 
     def _bundle_to_dict(self, bundle: CatalogBundle) -> dict[str, dict[str, Catalog]]:
         return {
@@ -118,10 +525,12 @@ class CatalogService:
         self,
         movie_history: list[dict[str, Any]],
         show_history: list[dict[str, Any]],
+        *,
+        catalog_count: int,
     ) -> dict[str, Any]:
         return {
             "generated_at": datetime.utcnow().isoformat(),
-            "catalog_count": self._settings.catalog_count,
+            "catalog_count": catalog_count,
             "profile": {
                 "movies": TraktClient.summarize_history(movie_history, key="movie"),
                 "series": TraktClient.summarize_history(show_history, key="show"),
@@ -198,69 +607,79 @@ class CatalogService:
             poster = self._extract_image(media)
             if poster:
                 data["poster"] = poster
-            background = self._extract_image(media, variant="fanart")
+            background = self._extract_image(media, key="background")
             if background:
                 data["background"] = background
-
             try:
                 item = CatalogItem.model_validate(data)
             except ValidationError:
                 continue
             items.append(item)
 
-        catalog_id = slugify(f"{title}-{seed[:6]}")
+        catalog_id = slugify(title) or f"history-{content_type}-{seed}"
         return Catalog(
             id=f"aiopicks-{content_type}-{catalog_id}",
-            type=content_type,  # type: ignore[arg-type]
+            type=content_type,
             title=title,
-            description="Fallback catalog generated from your Trakt history.",
+            description=f"Curated from your recent {content_type} history.",
             seed=seed,
             items=items,
             generated_at=datetime.utcnow(),
         )
 
-    @staticmethod
-    def _extract_image(media: dict[str, Any], *, variant: str = "poster") -> str | None:
-        images = media.get("images")
-        if isinstance(images, dict):
-            variant_data = images.get(variant)
-            if isinstance(variant_data, dict):
-                for key in ("full", "medium", "thumb"):
-                    value = variant_data.get(key)
-                    if isinstance(value, str) and value.startswith("http"):
-                        return value
-        # fallback to direct fields some Trakt payloads expose
-        field = media.get(f"{variant}")
-        if isinstance(field, str) and field.startswith("http"):
-            return field
+    async def _load_catalogs(
+        self, profile_id: str, content_type: str | None = None
+    ) -> list[Catalog]:
+        async with self._session_factory() as session:
+            stmt = select(CatalogRecord).where(CatalogRecord.profile_id == profile_id)
+            if content_type:
+                stmt = stmt.where(CatalogRecord.content_type == content_type)
+            stmt = stmt.order_by(CatalogRecord.content_type, CatalogRecord.position)
+            result = await session.execute(stmt)
+            records = result.scalars().all()
+        catalogs: list[Catalog] = []
+        for record in records:
+            try:
+                catalogs.append(Catalog.model_validate(record.payload))
+            except ValidationError as exc:
+                logger.warning(
+                    "Stored catalog for profile %s could not be validated: %s",
+                    profile_id,
+                    exc,
+                )
+        return catalogs
+
+    async def _load_single_catalog(
+        self, profile_id: str, content_type: str, catalog_id: str
+    ) -> Catalog | None:
+        async with self._session_factory() as session:
+            stmt = select(CatalogRecord).where(
+                CatalogRecord.profile_id == profile_id,
+                CatalogRecord.content_type == content_type,
+                CatalogRecord.catalog_id == catalog_id,
+            )
+            result = await session.execute(stmt)
+            record = result.scalar_one_or_none()
+            if record is None:
+                return None
+            payload = record.payload
+        try:
+            return Catalog.model_validate(payload)
+        except ValidationError as exc:
+            logger.warning(
+                "Stored catalog %s for profile %s is invalid: %s",
+                catalog_id,
+                profile_id,
+                exc,
+            )
+            return None
+
+    def _extract_image(self, media: dict[str, Any], *, key: str = "poster") -> str | None:
+        images = media.get("images") or {}
+        if not isinstance(images, dict):
+            return None
+        url = images.get(key) or images.get(f"{key}_full") or images.get(f"{key}_url")
+        if isinstance(url, str) and url.startswith("http"):
+            return url
         return None
 
-    async def list_manifest_catalogs(self) -> list[dict[str, object]]:
-        await self.ensure_catalogs()
-        entries: list[dict[str, object]] = []
-        for content_type in ("movie", "series"):
-            for catalog in self._catalogs.get(content_type, {}).values():
-                entries.append(catalog.to_manifest_entry())
-        return entries
-
-    async def get_catalog_payload(self, content_type: str, catalog_id: str) -> dict[str, object]:
-        await self.ensure_catalogs()
-        catalogs = self._catalogs.get(content_type)
-        if not catalogs:
-            raise KeyError(f"Unknown catalog type: {content_type}")
-        catalog = catalogs.get(catalog_id)
-        if not catalog:
-            raise KeyError(f"Catalog {catalog_id} not found")
-        return catalog.to_catalog_response()
-
-    async def find_meta(self, content_type: str, meta_id: str) -> dict[str, object]:
-        await self.ensure_catalogs()
-        catalogs = self._catalogs.get(content_type)
-        if not catalogs:
-            raise KeyError(f"Unknown catalog type: {content_type}")
-        for catalog in catalogs.values():
-            payload = catalog.to_catalog_response()
-            for meta in payload.get("metas", []):
-                if meta.get("id") == meta_id:
-                    return meta
-        raise KeyError(f"Meta {meta_id} not found in {content_type} catalogs")

--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -85,11 +85,18 @@ class OpenRouterClient:
         summary: dict[str, Any],
         *,
         seed: str,
+        api_key: str | None = None,
+        model: str | None = None,
     ) -> CatalogBundle:
         """Generate new catalogs using the configured model."""
 
         catalog_count = summary.get("catalog_count", self._settings.catalog_count)
         profile = summary.get("profile", {})
+
+        resolved_model = model or self._settings.openrouter_model
+        resolved_key = api_key or self._settings.openrouter_api_key
+        if not resolved_key:
+            raise RuntimeError("OpenRouter API key is required to generate catalogs")
 
         prompt = USER_PROMPT_TEMPLATE.format(
             generated_at=summary.get("generated_at"),
@@ -106,7 +113,7 @@ class OpenRouterClient:
         )
 
         payload = {
-            "model": self._settings.openrouter_model,
+            "model": resolved_model,
             "temperature": 1.1,
             "top_p": 0.9,
             "max_output_tokens": 2_500,
@@ -117,7 +124,7 @@ class OpenRouterClient:
         }
 
         headers = {
-            "Authorization": f"Bearer {self._settings.openrouter_api_key}",
+            "Authorization": f"Bearer {resolved_key}",
             "Content-Type": "application/json",
             "HTTP-Referer": "https://github.com/aiopicks/aiopicks",
             "X-Title": "AIOPicks Python",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "httpx>=0.27,<0.28",
     "pydantic>=2.7,<3",
     "pydantic-settings>=2.2,<3",
+    "SQLAlchemy>=2.0,<3",
+    "aiosqlite>=0.19,<0.21",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add SQLAlchemy and aiosqlite along with a database wrapper and ORM models for storing user profiles and catalog payloads
- refactor the catalog service to persist per-profile settings in the database, refresh catalogs on-demand/background, and honor manifest query overrides
- update the FastAPI endpoints plus Trakt/OpenRouter clients to resolve request-scoped configs and use profile-specific credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca0142736083228726af57b63f32b6