### PR TITLE
Fix Nixpacks entrypoint for aiopicks package

### DIFF
--- a/aiopicks/__init__.py
+++ b/aiopicks/__init__.py
@@ -1,0 +1,7 @@
+"""Compatibility shim exposing the main FastAPI app."""
+
+from __future__ import annotations
+
+from app.main import app, create_app
+
+__all__ = ["app", "create_app"]

--- a/aiopicks/__main__.py
+++ b/aiopicks/__main__.py
@@ -1,0 +1,22 @@
+"""Module executed when running ``python -m aiopicks``."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from app.config import settings
+
+
+def main() -> None:
+    """Start the uvicorn server using the configured settings."""
+
+    uvicorn.run(
+        "app.main:app",
+        host=settings.server_host,
+        port=settings.server_port,
+        reload=settings.environment == "development",
+    )
+
+
+if __name__ == "__main__":  # pragma: no cover - runtime entrypoint
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dev = [
 
 [tool.setuptools.packages.find]
 where = ["."]
-include = ["app*"]
+include = ["app*", "aiopicks*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- expose the FastAPI application through a new `aiopicks` package that matches the project name
- add a `python -m aiopicks` runner that launches uvicorn with the configured settings
- update package discovery so the new module is included when building the project

## Testing
- pip install -e .[dev]
- pytest
- python -m aiopicks

------
https://chatgpt.com/codex/tasks/task_b_68ca09846c4883228f0efaf7e48a12e5