### PR TITLE
Allow startup without OpenRouter API key

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,7 +20,9 @@ class Settings(BaseSettings):
     trakt_access_token: str | None = Field(default=None, alias="TRAKT_ACCESS_TOKEN")
     trakt_history_limit: int = Field(default=500, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000)
 
-    openrouter_api_key: str = Field(alias="OPENROUTER_API_KEY")
+    openrouter_api_key: str | None = Field(
+        default=None, alias="OPENROUTER_API_KEY"
+    )
     openrouter_model: str = Field(
         default="google/gemini-2.5-flash-lite", alias="OPENROUTER_MODEL"
     )

--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -467,9 +467,10 @@ class CatalogService:
             now = datetime.utcnow()
             if profile is None:
                 if not self._settings.openrouter_api_key:
-                    raise RuntimeError(
-                        "OPENROUTER_API_KEY must be configured for the default profile"
+                    logger.warning(
+                        "Skipping default profile creation because OPENROUTER_API_KEY is not set"
                     )
+                    return
                 profile = Profile(
                     id="default",
                     openrouter_api_key=self._settings.openrouter_api_key,

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+from app.config import Settings
+from app.database import Database
+from app.services.catalog_generator import CatalogService
+from app.services.openrouter import OpenRouterClient
+from app.services.trakt import TraktClient
+
+
+def test_default_profile_skipped_without_api_key(tmp_path) -> None:
+    """The default profile should not be created when no API key is configured."""
+
+    async def runner() -> None:
+        database_path = tmp_path / "service.db"
+        database = Database(f"sqlite+aiosqlite:///{database_path}")
+        await database.create_all()
+
+        settings = Settings(_env_file=None)
+        assert settings.openrouter_api_key is None
+
+        service = CatalogService(
+            settings,
+            cast(TraktClient, object()),
+            cast(OpenRouterClient, object()),
+            database.session_factory,
+        )
+
+        await service._ensure_default_profile()
+        state = await service._load_profile_state("default")
+
+        assert state is None
+
+        await database.dispose()
+
+    asyncio.run(runner())


### PR DESCRIPTION
## Summary
- allow the OpenRouter API key setting to be optional and skip default profile creation when it is absent
- add a regression test covering startup without a configured key to ensure the catalog service no longer raises

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ca0b24454483228c3ddeabea88111c