### PR TITLE
Use server Trakt credentials for device login

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,6 +2,7 @@
 OPENROUTER_API_KEY=replace-with-your-openrouter-key
 OPENROUTER_MODEL=google/gemini-2.5-flash-lite
 TRAKT_CLIENT_ID=replace-with-trakt-client-id
+TRAKT_CLIENT_SECRET=replace-with-trakt-client-secret
 TRAKT_ACCESS_TOKEN=replace-with-trakt-access-token
 CATALOG_COUNT=6
 REFRESH_INTERVAL=43200

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Create a `.env` file (or copy `.env.sample`) with your credentials:
 OPENROUTER_API_KEY=your-openrouter-key
 OPENROUTER_MODEL=google/gemini-2.5-flash-lite
 TRAKT_CLIENT_ID=your-trakt-client-id
+TRAKT_CLIENT_SECRET=your-trakt-client-secret
 TRAKT_ACCESS_TOKEN=your-trakt-access-token
 CATALOG_COUNT=6
 REFRESH_INTERVAL=43200  # seconds
@@ -60,7 +61,8 @@ CACHE_TTL=1800          # seconds
 ```
 
 > ℹ️ You can obtain a Trakt access token by creating a personal application and using the device code flow. Store the
-> long-lived access token for this addon.
+> long-lived access token for this addon. The `/config` helper automatically uses `TRAKT_CLIENT_ID` and
+> `TRAKT_CLIENT_SECRET` from the server environment when minting device codes—secrets never touch the browser.
 
 ## 🧪 Local Development
 

--- a/app/config.py
+++ b/app/config.py
@@ -17,6 +17,9 @@ class Settings(BaseSettings):
     server_port: int = Field(default=3000, alias="PORT")
 
     trakt_client_id: str | None = Field(default=None, alias="TRAKT_CLIENT_ID")
+    trakt_client_secret: str | None = Field(
+        default=None, alias="TRAKT_CLIENT_SECRET"
+    )
     trakt_access_token: str | None = Field(default=None, alias="TRAKT_ACCESS_TOKEN")
     trakt_history_limit: int = Field(default=500, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000)
 


### PR DESCRIPTION
## Summary
- add support for configuring the Trakt client secret via environment settings
- update the /config page and device login helper to use server-managed Trakt credentials
- document the new environment variable and keep secrets out of the browser UI

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb184e5204832283f91832c7dbb3dd