### PR TITLE
Replace Trakt device flow with OAuth redirect login

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     trakt_api_url: HttpUrl = Field(
         default="https://api.trakt.tv", alias="TRAKT_API_URL"
     )
+    trakt_authorize_url: HttpUrl = Field(
+        default="https://trakt.tv/oauth/authorize", alias="TRAKT_AUTHORIZE_URL"
+    )
     openrouter_api_url: HttpUrl = Field(
         default="https://openrouter.ai/api/v1", alias="OPENROUTER_API_URL"
     )

--- a/app/web.py
+++ b/app/web.py
@@ -94,8 +94,6 @@ CONFIG_TEMPLATE = dedent(
             color: rgba(148,163,184,0.92);
         }
         input[type="text"],
-        input[type="number"],
-        input[type="password"],
         select {
             width: 100%;
             background: rgba(15,23,42,0.95);
@@ -107,8 +105,6 @@ CONFIG_TEMPLATE = dedent(
             transition: border 0.2s ease, box-shadow 0.2s ease;
         }
         input[type="text"]:focus,
-        input[type="number"]:focus,
-        input[type="password"]:focus,
         select:focus {
             outline: none;
             border-color: rgba(129,140,248,0.8);
@@ -151,41 +147,29 @@ CONFIG_TEMPLATE = dedent(
             cursor: not-allowed;
             opacity: 0.6;
         }
-        code.inline {
-            font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, monospace;
-            background: rgba(15,23,42,0.9);
-            padding: 0.25rem 0.45rem;
-            border-radius: 8px;
-            border: 1px solid rgba(148,163,184,0.2);
-        }
         .muted {
             font-size: 0.85rem;
             color: rgba(148,163,184,0.9);
         }
+        .notice {
+            margin-bottom: 1rem;
+            padding: 0.75rem 1rem;
+            border-radius: 14px;
+            background: rgba(15,23,42,0.9);
+            border: 1px dashed rgba(148,163,184,0.35);
+            color: rgba(226,232,240,0.88);
+        }
         .status {
-            margin-top: 0.75rem;
-            font-size: 0.9rem;
+            margin-top: 0.85rem;
+            font-size: 0.95rem;
             color: rgba(226,232,240,0.92);
+            min-height: 1.2em;
         }
         .status.error {
             color: #fca5a5;
         }
         .status.success {
             color: #86efac;
-        }
-        .token-output {
-            margin-top: 1rem;
-            display: grid;
-            gap: 0.5rem;
-        }
-        .token-output .token-line {
-            display: flex;
-            gap: 0.5rem;
-            align-items: center;
-        }
-        .token-output input {
-            flex: 1;
-            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
         }
         .preview {
             background: rgba(15,23,42,0.9);
@@ -197,15 +181,6 @@ CONFIG_TEMPLATE = dedent(
             font-size: 0.9rem;
             word-break: break-all;
             color: rgba(226,232,240,0.9);
-        }
-        .step-list {
-            padding-left: 1.25rem;
-            margin-top: 0.35rem;
-            margin-bottom: 1rem;
-            color: rgba(226,232,240,0.9);
-        }
-        .step-list li + li {
-            margin-top: 0.35rem;
         }
         .pill {
             display: inline-flex;
@@ -241,14 +216,23 @@ CONFIG_TEMPLATE = dedent(
         <header>
             <p class="pill">Stremio Add-on • __OPENROUTER_MODEL__</p>
             <h1>Configure __APP_NAME__</h1>
-            <p>Generate a personalised manifest link, guide users through Trakt device login, and share
-            your AI powered addon with the world.</p>
+            <p>Connect your Trakt account and generate a personalised manifest link for Stremio.</p>
         </header>
         <div class="grid">
-            <section class="card">
+            <section class="card" id="trakt-card">
+                <h2>Connect Trakt</h2>
+                <p class="description">Sign in seamlessly—no device codes or copy/paste hoops required.</p>
+                <p class="muted" id="trakt-hint"></p>
+                <div class="actions">
+                    <button id="trakt-login" type="button">Sign in with Trakt</button>
+                    <button id="trakt-disconnect" type="button" class="secondary hidden">Disconnect</button>
+                </div>
+                <div class="status" id="trakt-status"></div>
+            </section>
+            <section class="card" id="manifest-card">
                 <h2>Manifest builder</h2>
-                <p class="description">Choose how many AI generated catalogs to expose and copy a ready-to-install
-                manifest URL. Empty fields fall back to the server defaults.</p>
+                <p class="description">Choose how many AI generated catalogs to expose and copy a ready-to-install manifest URL. Empty fields fall back to the server defaults.</p>
+                <p class="notice hidden" id="manifest-lock">Sign in with Trakt to unlock personalised manifest links.</p>
                 <div class="field">
                     <label for="config-openrouter-key">OpenRouter API key <span class="helper">Optional – stored client side only</span></label>
                     <input id="config-openrouter-key" type="text" placeholder="sk-or-..." autocomplete="off" spellcheck="false" />
@@ -279,14 +263,6 @@ CONFIG_TEMPLATE = dedent(
                         <option value="3600">60 minutes</option>
                     </select>
                 </div>
-                <div class="field">
-                    <label for="config-trakt-client-id">Trakt client ID <span class="helper">Optional – improves rate limits</span></label>
-                    <input id="config-trakt-client-id" type="text" placeholder="public-client-id" spellcheck="false" />
-                </div>
-                <div class="field">
-                    <label for="config-trakt-access-token">Trakt access token <span class="helper">Paste the device token below</span></label>
-                    <input id="config-trakt-access-token" type="text" placeholder="long-lived token" spellcheck="false" />
-                </div>
                 <div class="actions">
                     <button id="copy-default-manifest" type="button">Copy public manifest</button>
                     <button id="copy-configured-manifest" type="button" class="secondary">Copy configured manifest</button>
@@ -294,419 +270,345 @@ CONFIG_TEMPLATE = dedent(
                 <p class="muted" id="copy-message"></p>
                 <div class="preview" id="manifest-preview"></div>
             </section>
-            <section class="card">
-                <h2>Trakt device login helper</h2>
-                <p class="description">No need to leave the page—launch the device flow with the server's stored Trakt
-                credentials. Secrets never touch the browser.</p>
-                <ol class="step-list">
-                    <li>Click <em>Start device login</em> to fetch a fresh device code.</li>
-                    <li>Follow the verification link and approve the request on Trakt.</li>
-                    <li>Copy the access token straight into the manifest builder.</li>
-                </ol>
-                <div class="actions">
-                    <button id="start-trakt-login" type="button">Start device login</button>
-                </div>
-                <div class="status" id="trakt-status"></div>
-                <div id="trakt-code" class="hidden">
-                    <p>Visit <a id="trakt-verification" href="https://trakt.tv/activate" target="_blank" rel="noreferrer">trakt.tv/activate</a> and enter code
-                    <code class="inline" id="trakt-user-code"></code>.</p>
-                    <div class="actions">
-                        <button id="copy-user-code" type="button" class="secondary">Copy code</button>
-                    </div>
-                    <p class="muted" id="trakt-countdown"></p>
-                </div>
-                <div class="token-output hidden" id="trakt-token-output">
-                    <div class="token-line">
-                        <input id="trakt-access-value" readonly />
-                        <button id="copy-access-token" type="button" class="secondary">Copy access token</button>
-                    </div>
-                    <div class="token-line">
-                        <input id="trakt-refresh-value" readonly placeholder="Refresh token (optional)" />
-                        <button id="copy-refresh-token" type="button" class="secondary">Copy refresh token</button>
-                    </div>
-                </div>
-            </section>
         </div>
     </main>
     <script>
-    (() => {
-        const defaults = __DEFAULTS_JSON__;
-        const baseManifestUrl = new URL('/manifest.json', window.location.origin).toString();
+        (function () {
+            const defaults = JSON.parse('__DEFAULTS_JSON__');
+            const baseManifestUrl = new URL('/manifest.json', window.location.origin).toString();
 
-        const catalogSlider = document.getElementById('config-catalog-count');
-        const catalogValue = document.getElementById('catalog-count-value');
-        const openrouterModel = document.getElementById('config-openrouter-model');
-        const openrouterKey = document.getElementById('config-openrouter-key');
-        const refreshSelect = document.getElementById('config-refresh-interval');
-        const cacheSelect = document.getElementById('config-cache-ttl');
-        const traktClientId = document.getElementById('config-trakt-client-id');
-        const traktAccessToken = document.getElementById('config-trakt-access-token');
-        const manifestPreview = document.getElementById('manifest-preview');
-        const copyMessage = document.getElementById('copy-message');
+            const openrouterKey = document.getElementById('config-openrouter-key');
+            const openrouterModel = document.getElementById('config-openrouter-model');
+            const catalogSlider = document.getElementById('config-catalog-count');
+            const catalogValue = document.getElementById('catalog-count-value');
+            const refreshSelect = document.getElementById('config-refresh-interval');
+            const cacheSelect = document.getElementById('config-cache-ttl');
+            const copyDefaultManifest = document.getElementById('copy-default-manifest');
+            const copyConfiguredManifest = document.getElementById('copy-configured-manifest');
+            const manifestPreview = document.getElementById('manifest-preview');
+            const copyMessage = document.getElementById('copy-message');
+            const manifestLock = document.getElementById('manifest-lock');
 
-        const traktLoginButton = document.getElementById('start-trakt-login');
-        const traktStatus = document.getElementById('trakt-status');
-        const traktCodeContainer = document.getElementById('trakt-code');
-        const traktCountdown = document.getElementById('trakt-countdown');
-        const traktCodeValue = document.getElementById('trakt-user-code');
-        const traktVerificationLink = document.getElementById('trakt-verification');
-        const traktTokenOutput = document.getElementById('trakt-token-output');
-        const traktCopyCodeButton = document.getElementById('copy-user-code');
-        const traktCopyAccessButton = document.getElementById('copy-access-token');
-        const traktCopyRefreshButton = document.getElementById('copy-refresh-token');
-        const traktAccessOutput = document.getElementById('trakt-access-value');
-        const traktRefreshOutput = document.getElementById('trakt-refresh-value');
+            const traktLoginButton = document.getElementById('trakt-login');
+            const traktDisconnectButton = document.getElementById('trakt-disconnect');
+            const traktStatus = document.getElementById('trakt-status');
+            const traktHint = document.getElementById('trakt-hint');
+            const traktLoginAvailable = Boolean(defaults.traktLoginAvailable);
 
-        const serverTraktClientId = (defaults.traktClientId || '').trim();
-        const deviceFlowAvailable = Boolean(
-            defaults.traktDeviceAuthEnabled && serverTraktClientId
-        );
+            const traktAuth = { accessToken: '', refreshToken: '' };
+            let traktPending = false;
+            let copyTimeout = null;
 
-        const refreshDefaults = String(defaults.refreshIntervalSeconds || 43200);
-        const cacheDefaults = String(defaults.responseCacheSeconds || 1800);
-
-        openrouterModel.value = defaults.openrouterModel || '';
-        catalogSlider.value = String(defaults.catalogCount || 6);
-        catalogValue.textContent = catalogSlider.value;
-        traktClientId.value = defaults.traktClientId || '';
-        traktAccessToken.value = defaults.traktAccessToken || '';
-
-        if (!deviceFlowAvailable) {
-            traktLoginButton.disabled = true;
-            traktLoginButton.textContent = 'Device login unavailable';
-            showTraktStatus(
-                'Server is not configured with a Trakt client ID and secret. Set TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET to enable device login.',
-                true
-            );
-        }
-
-        ensureOption(refreshSelect, refreshDefaults, formatSeconds(Number(refreshDefaults)));
-        ensureOption(cacheSelect, cacheDefaults, formatSeconds(Number(cacheDefaults)));
-        refreshSelect.value = refreshDefaults;
-        cacheSelect.value = cacheDefaults;
-
-        updateManifestPreview();
-
-        catalogSlider.addEventListener('input', () => {
+            openrouterModel.value = defaults.openrouterModel || '';
+            catalogSlider.value = defaults.catalogCount || catalogSlider.min || 1;
             catalogValue.textContent = catalogSlider.value;
+            refreshSelect.value = String(defaults.refreshIntervalSeconds || refreshSelect.value);
+            ensureOption(refreshSelect, refreshSelect.value, formatSeconds(Number(refreshSelect.value)));
+            cacheSelect.value = String(defaults.responseCacheSeconds || cacheSelect.value);
+            ensureOption(cacheSelect, cacheSelect.value, formatSeconds(Number(cacheSelect.value)));
+
+            const storedTokens = readStoredTokens();
+            if (storedTokens && storedTokens.access_token) {
+                applyTraktTokens(storedTokens, { silent: true });
+            } else if ((defaults.traktAccessToken || '').trim()) {
+                applyTraktTokens({ access_token: defaults.traktAccessToken }, { silent: true });
+            } else {
+                updateTraktUi();
+            }
+            refreshTraktMessaging();
             updateManifestPreview();
-        });
 
-        [openrouterModel, openrouterKey, refreshSelect, cacheSelect, traktClientId, traktAccessToken].forEach((el) => {
-            el.addEventListener('input', updateManifestPreview);
-            el.addEventListener('change', updateManifestPreview);
-        });
+            catalogSlider.addEventListener('input', () => {
+                catalogValue.textContent = catalogSlider.value;
+                updateManifestPreview();
+            });
+            openrouterModel.addEventListener('input', updateManifestPreview);
+            openrouterKey.addEventListener('input', updateManifestPreview);
+            refreshSelect.addEventListener('change', () => {
+                ensureOption(refreshSelect, refreshSelect.value, formatSeconds(Number(refreshSelect.value)));
+                updateManifestPreview();
+            });
+            cacheSelect.addEventListener('change', () => {
+                ensureOption(cacheSelect, cacheSelect.value, formatSeconds(Number(cacheSelect.value)));
+                updateManifestPreview();
+            });
 
-        document.getElementById('copy-default-manifest').addEventListener('click', async () => {
-            await copyToClipboard(baseManifestUrl);
-            setCopyMessage('Base manifest URL copied to clipboard.');
-        });
+            copyDefaultManifest.addEventListener('click', async () => {
+                await copyToClipboard(baseManifestUrl);
+                setCopyMessage('Base manifest URL copied to clipboard.');
+            });
 
-        document.getElementById('copy-configured-manifest').addEventListener('click', async () => {
-            const url = buildConfiguredUrl();
-            await copyToClipboard(url);
-            setCopyMessage('Configured manifest URL copied. Install it in Stremio to use your settings.');
-        });
+            copyConfiguredManifest.addEventListener('click', async () => {
+                const url = buildConfiguredUrl();
+                await copyToClipboard(url);
+                setCopyMessage('Configured manifest URL copied. Install it in Stremio to use your settings.');
+            });
 
-        traktCopyCodeButton.addEventListener('click', () => copyToClipboard(traktCodeValue.textContent));
-        traktCopyAccessButton.addEventListener('click', () => copyToClipboard(traktAccessOutput.value));
-        traktCopyRefreshButton.addEventListener('click', () => {
-            if (traktRefreshOutput.value) {
-                copyToClipboard(traktRefreshOutput.value);
-            }
-        });
-
-        let copyTimeout = null;
-        function setCopyMessage(message) {
-            copyMessage.textContent = message;
-            if (copyTimeout) {
-                clearTimeout(copyTimeout);
-            }
-            if (message) {
-                copyTimeout = setTimeout(() => {
-                    copyMessage.textContent = '';
-                }, 6000);
-            }
-        }
-
-        function buildConfiguredUrl() {
-            const url = new URL(baseManifestUrl);
-            const params = new URLSearchParams();
-            const key = openrouterKey.value.trim();
-            if (key) params.set('openrouterKey', key);
-            const model = openrouterModel.value.trim();
-            if (model) params.set('openrouterModel', model);
-            const count = catalogSlider.value;
-            if (count) params.set('catalogCount', count);
-            const refresh = refreshSelect.value;
-            if (refresh) params.set('refreshInterval', refresh);
-            const cache = cacheSelect.value;
-            if (cache) params.set('cacheTtl', cache);
-            const traktId = traktClientId.value.trim();
-            if (traktId) params.set('traktClientId', traktId);
-            const traktToken = traktAccessToken.value.trim();
-            if (traktToken) params.set('traktAccessToken', traktToken);
-            url.search = params.toString();
-            return url.toString();
-        }
-
-        function updateManifestPreview() {
-            manifestPreview.textContent = buildConfiguredUrl();
-        }
-
-        async function copyToClipboard(value) {
-            try {
-                await navigator.clipboard.writeText(value);
-            } catch (err) {
-                const textarea = document.createElement('textarea');
-                textarea.value = value;
-                textarea.setAttribute('readonly', '');
-                textarea.style.position = 'absolute';
-                textarea.style.left = '-9999px';
-                document.body.appendChild(textarea);
-                textarea.select();
-                document.execCommand('copy');
-                document.body.removeChild(textarea);
-            }
-        }
-
-        function ensureOption(select, value, label) {
-            const exists = Array.from(select.options).some((option) => option.value === value);
-            if (!exists) {
-                const option = document.createElement('option');
-                option.value = value;
-                option.textContent = `Custom (${label})`;
-                select.appendChild(option);
-            }
-        }
-
-        function formatSeconds(seconds) {
-            if (!Number.isFinite(seconds) || seconds <= 0) {
-                return 'custom';
-            }
-            if (seconds % 3600 === 0) {
-                const hours = seconds / 3600;
-                return hours === 1 ? '1 hour' : `${hours} hours`;
-            }
-            if (seconds % 60 === 0) {
-                const minutes = seconds / 60;
-                return minutes === 1 ? '1 minute' : `${minutes} minutes`;
-            }
-            return `${seconds} seconds`;
-        }
-
-        function showTraktStatus(message, isError = false, isSuccess = false) {
-            traktStatus.textContent = message;
-            traktStatus.classList.toggle('error', isError);
-            traktStatus.classList.toggle('success', isSuccess);
-            if (!message) {
-                traktStatus.classList.remove('error');
-                traktStatus.classList.remove('success');
-            }
-        }
-
-        const traktState = { pollTimer: null, pollInterval: 5000, expiresAt: null, deviceCode: null };
-        let countdownTimer = null;
-
-        traktLoginButton.addEventListener('click', async () => {
-            if (!deviceFlowAvailable) {
-                showTraktStatus(
-                    'Server is not configured with a Trakt client ID and secret. Ask the administrator to set TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET.',
-                    true
-                );
-                return;
-            }
-
-            const clientId = serverTraktClientId;
-            if (!clientId) {
-                showTraktStatus(
-                    'Server is missing a Trakt client ID. Set TRAKT_CLIENT_ID in the environment to continue.',
-                    true
-                );
-                return;
-            }
-
-            resetTraktState();
-            traktLoginButton.disabled = true;
-            showTraktStatus('Requesting a device code from Trakt…');
-
-            try {
-                const response = await fetch('/api/trakt/device-code', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ client_id: clientId })
-                });
-                const payload = await response.json();
-                if (!response.ok) {
-                    showTraktStatus(resolveErrorMessage(payload), true);
-                    traktLoginButton.disabled = false;
+            traktLoginButton.addEventListener('click', async () => {
+                if (!traktLoginAvailable || traktPending) {
                     return;
                 }
-                traktState.deviceCode = payload.device_code;
-                traktState.pollInterval = ((payload.interval || 5) * 1000);
-                traktState.expiresAt = Date.now() + ((payload.expires_in || 600) * 1000);
-
-                traktCodeValue.textContent = payload.user_code || 'Unknown';
-                traktVerificationLink.href = payload.verification_url || 'https://trakt.tv/activate';
-                traktCodeContainer.classList.remove('hidden');
-                traktTokenOutput.classList.add('hidden');
-                startCountdown();
-                showTraktStatus('Enter the code on Trakt and approve access.');
-                schedulePoll(clientId);
-            } catch (error) {
-                console.error(error);
-                showTraktStatus('Could not reach the Trakt API. Check your connection and try again.', true);
-                traktLoginButton.disabled = false;
-            }
-        });
-
-        function resetTraktState() {
-            if (traktState.pollTimer) {
-                clearTimeout(traktState.pollTimer);
-                traktState.pollTimer = null;
-            }
-            if (countdownTimer) {
-                clearInterval(countdownTimer);
-                countdownTimer = null;
-            }
-            traktState.deviceCode = null;
-            traktState.expiresAt = null;
-            traktState.pollInterval = 5000;
-            traktCountdown.textContent = '';
-            traktCodeContainer.classList.add('hidden');
-            traktTokenOutput.classList.add('hidden');
-        }
-
-        function startCountdown() {
-            if (!traktState.expiresAt) return;
-            updateCountdown();
-            countdownTimer = setInterval(updateCountdown, 1000);
-        }
-
-        function updateCountdown() {
-            if (!traktState.expiresAt) return;
-            const remainingMs = traktState.expiresAt - Date.now();
-            if (remainingMs <= 0) {
-                traktCountdown.textContent = 'Device code expired. Start again for a new code.';
-                if (traktState.pollTimer) {
-                    clearTimeout(traktState.pollTimer);
-                    traktState.pollTimer = null;
-                }
-                traktLoginButton.disabled = false;
-                if (countdownTimer) {
-                    clearInterval(countdownTimer);
-                    countdownTimer = null;
-                }
-                return;
-            }
-            const totalSeconds = Math.floor(remainingMs / 1000);
-            const minutes = Math.floor(totalSeconds / 60);
-            const seconds = totalSeconds % 60;
-            traktCountdown.textContent = `Code expires in ${minutes}m ${String(seconds).padStart(2, '0')}s`;
-        }
-
-        function schedulePoll(clientId) {
-            if (traktState.pollTimer) {
-                clearTimeout(traktState.pollTimer);
-            }
-            traktState.pollTimer = setTimeout(
-                () => pollForToken(clientId),
-                traktState.pollInterval
-            );
-        }
-
-        async function pollForToken(clientId) {
-            if (!traktState.deviceCode) {
-                traktLoginButton.disabled = false;
-                return;
-            }
-            try {
-                const response = await fetch('/api/trakt/device-token', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        client_id: clientId,
-                        device_code: traktState.deviceCode
-                    })
-                });
-                const payload = await response.json();
-                if (response.ok) {
-                    showTraktStatus('Trakt authorised successfully! Tokens ready below.', false, true);
-                    traktLoginButton.disabled = false;
-                    if (traktState.pollTimer) {
-                        clearTimeout(traktState.pollTimer);
-                        traktState.pollTimer = null;
+                traktPending = true;
+                updateTraktUi();
+                showTraktStatus('Opening Trakt sign in…');
+                showTraktHint('A secure pop-up will appear. Approve access in Trakt and this page will update automatically.');
+                try {
+                    const response = await fetch('/api/trakt/login-url', { method: 'POST' });
+                    const payload = await response.json().catch(() => ({}));
+                    if (!response.ok || !payload.url) {
+                        traktPending = false;
+                        updateTraktUi();
+                        showTraktStatus(resolveErrorMessage(payload) || 'Unable to start Trakt sign in.', 'error');
+                        showTraktHint('Please try again in a moment.');
+                        return;
                     }
-                    if (countdownTimer) {
-                        clearInterval(countdownTimer);
-                        countdownTimer = null;
+                    const popup = window.open(payload.url, 'trakt-sign-in', 'width=600,height=780');
+                    if (!popup) {
+                        traktPending = false;
+                        updateTraktUi();
+                        showTraktStatus('Allow pop-ups for this site to continue with Trakt sign in.', 'error');
+                        showTraktHint('After enabling pop-ups, click “Sign in with Trakt” again.');
+                        return;
                     }
-                    traktCodeContainer.classList.add('hidden');
-                    traktTokenOutput.classList.remove('hidden');
-                    traktAccessOutput.value = payload.access_token || '';
-                    traktRefreshOutput.value = payload.refresh_token || '';
-                    if (payload.access_token) {
-                        traktAccessToken.value = payload.access_token;
-                        updateManifestPreview();
-                    }
-                    return;
+                    popup.focus();
+                } catch (error) {
+                    console.error(error);
+                    traktPending = false;
+                    updateTraktUi();
+                    showTraktStatus('Could not reach the server to start Trakt sign in.', 'error');
+                    showTraktHint('Check your connection and try again.');
                 }
+            });
 
-                const errorCode = extractErrorCode(payload);
-                if (errorCode === 'authorization_pending') {
-                    showTraktStatus('Waiting for you to approve the device on Trakt…');
-                    schedulePoll(clientId);
+            traktDisconnectButton.addEventListener('click', () => {
+                if (traktPending) {
                     return;
                 }
-                if (errorCode === 'slow_down') {
-                    traktState.pollInterval += 5000;
-                    showTraktStatus('Trakt asked us to slow down—retrying shortly…');
-                    schedulePoll(clientId);
+                traktAuth.accessToken = '';
+                traktAuth.refreshToken = '';
+                persistTraktTokens(null);
+                updateManifestPreview();
+                updateTraktUi();
+                showTraktStatus('Trakt disconnected. Sign in again to reconnect.');
+                showTraktHint('');
+            });
+
+            window.addEventListener('message', (event) => {
+                if (event.origin !== window.location.origin) {
                     return;
                 }
-                if (errorCode === 'expired_token') {
-                    showTraktStatus('Device code expired. Start again to mint a new token.', true);
+                const data = event.data || {};
+                if (data.source !== 'trakt-oauth') {
+                    return;
+                }
+                traktPending = false;
+                applyTraktTokens(data.tokens || {}, { silent: true });
+                updateTraktUi();
+                if (data.status === 'success' && traktAuth.accessToken) {
+                    refreshTraktMessaging();
+                } else if (data.status === 'success') {
+                    showTraktStatus('Trakt did not return an access token. Please try again.', 'error');
+                    showTraktHint('Approve the access request in the Trakt window to finish linking.');
                 } else {
-                    showTraktStatus(resolveErrorMessage(payload), true);
+                    showTraktStatus(
+                        data.error_description || data.error || 'Trakt rejected the sign in request.',
+                        'error'
+                    );
+                    showTraktHint('Try again and ensure you approve the request in Trakt.');
                 }
-                traktLoginButton.disabled = false;
-                if (traktState.pollTimer) {
-                    clearTimeout(traktState.pollTimer);
-                    traktState.pollTimer = null;
-                }
-            } catch (error) {
-                console.error(error);
-                showTraktStatus('Network error while contacting Trakt.', true);
-                traktLoginButton.disabled = false;
-                if (traktState.pollTimer) {
-                    clearTimeout(traktState.pollTimer);
-                    traktState.pollTimer = null;
-                }
-            }
-        }
+            });
 
-        function extractErrorCode(payload) {
-            if (!payload) return null;
-            if (typeof payload.detail === 'string') return payload.detail;
-            if (payload.detail && typeof payload.detail === 'object') {
-                return payload.detail.error || payload.detail.code || null;
+            function setCopyMessage(message) {
+                copyMessage.textContent = message;
+                if (copyTimeout) {
+                    clearTimeout(copyTimeout);
+                }
+                if (message) {
+                    copyTimeout = setTimeout(() => {
+                        copyMessage.textContent = '';
+                    }, 6000);
+                }
             }
-            return payload.error || payload.error_code || null;
-        }
 
-        function resolveErrorMessage(payload) {
-            if (!payload) {
-                return 'Unexpected error communicating with Trakt.';
+            function buildConfiguredUrl() {
+                const url = new URL(baseManifestUrl);
+                const params = new URLSearchParams();
+                const key = openrouterKey.value.trim();
+                if (key) params.set('openrouterKey', key);
+                const model = openrouterModel.value.trim();
+                if (model) params.set('openrouterModel', model);
+                const count = catalogSlider.value;
+                if (count) params.set('catalogCount', count);
+                const refresh = refreshSelect.value;
+                if (refresh) params.set('refreshInterval', refresh);
+                const cache = cacheSelect.value;
+                if (cache) params.set('cacheTtl', cache);
+                if (traktAuth.accessToken) {
+                    params.set('traktAccessToken', traktAuth.accessToken);
+                }
+                url.search = params.toString();
+                return url.toString();
             }
-            if (typeof payload.detail === 'string') {
-                return payload.detail;
+
+            function updateManifestPreview() {
+                manifestPreview.textContent = buildConfiguredUrl();
+                copyConfiguredManifest.disabled = traktLoginAvailable && !traktAuth.accessToken;
+                manifestLock.classList.toggle('hidden', !traktLoginAvailable || Boolean(traktAuth.accessToken));
             }
-            if (payload.detail && typeof payload.detail === 'object') {
-                return payload.detail.description || payload.detail.error || 'Trakt rejected the request.';
+
+            async function copyToClipboard(value) {
+                try {
+                    await navigator.clipboard.writeText(value);
+                } catch (err) {
+                    const textarea = document.createElement('textarea');
+                    textarea.value = value;
+                    textarea.setAttribute('readonly', '');
+                    textarea.style.position = 'absolute';
+                    textarea.style.left = '-9999px';
+                    document.body.appendChild(textarea);
+                    textarea.select();
+                    document.execCommand('copy');
+                    document.body.removeChild(textarea);
+                }
             }
-            return payload.message || payload.error_description || payload.error || 'Trakt rejected the request.';
-        }
-    })();
+
+            function ensureOption(select, value, label) {
+                const exists = Array.from(select.options).some((option) => option.value === value);
+                if (!exists) {
+                    const option = document.createElement('option');
+                    option.value = value;
+                    option.textContent = `Custom (${label})`;
+                    select.appendChild(option);
+                }
+            }
+
+            function formatSeconds(seconds) {
+                if (!Number.isFinite(seconds) || seconds <= 0) {
+                    return 'custom';
+                }
+                if (seconds % 3600 === 0) {
+                    const hours = seconds / 3600;
+                    return hours === 1 ? '1 hour' : `${hours} hours`;
+                }
+                if (seconds % 60 === 0) {
+                    const minutes = seconds / 60;
+                    return minutes === 1 ? '1 minute' : `${minutes} minutes`;
+                }
+                return `${seconds} seconds`;
+            }
+
+            function updateTraktUi() {
+                const connected = Boolean(traktAuth.accessToken);
+                traktLoginButton.classList.toggle('hidden', !traktLoginAvailable || connected);
+                traktDisconnectButton.classList.toggle('hidden', !connected);
+                traktLoginButton.disabled = !traktLoginAvailable || traktPending;
+                traktDisconnectButton.disabled = traktPending || !connected;
+            }
+
+            function refreshTraktMessaging() {
+                if (!traktLoginAvailable) {
+                    showTraktStatus(
+                        'Server is not configured with Trakt credentials. Ask the administrator to set TRAKT_CLIENT_ID and TRAKT_CLIENT_SECRET.',
+                        'error'
+                    );
+                    showTraktHint('');
+                    return;
+                }
+                if (traktPending) {
+                    showTraktStatus('Waiting for you to finish signing in on Trakt…');
+                    showTraktHint('');
+                    return;
+                }
+                if (traktAuth.accessToken) {
+                    showTraktStatus('Trakt connected! Manifest links now include your access token automatically.', 'success');
+                    if (traktAuth.refreshToken) {
+                        showTraktHint('Your tokens are stored locally in this browser so you stay signed in next time.');
+                    } else {
+                        showTraktHint('Your access token is stored locally in this browser for manifest generation.');
+                    }
+                    return;
+                }
+                showTraktStatus('Sign in to Trakt to unlock personalised recommendations.');
+                showTraktHint('A secure pop-up will open and you simply approve access—no codes required.');
+            }
+
+            function applyTraktTokens(tokens, options = {}) {
+                const access = ((tokens && (tokens.access_token || tokens.accessToken)) || '').trim();
+                const refresh = ((tokens && (tokens.refresh_token || tokens.refreshToken)) || '').trim();
+                traktAuth.accessToken = access;
+                traktAuth.refreshToken = refresh;
+                persistTraktTokens(access ? { access_token: access, refresh_token: refresh } : null);
+                updateTraktUi();
+                if (!options.silent) {
+                    if (access) {
+                        refreshTraktMessaging();
+                    } else {
+                        showTraktStatus('Trakt tokens cleared. Sign in again to reconnect.');
+                        showTraktHint('');
+                    }
+                }
+                updateManifestPreview();
+            }
+
+            function persistTraktTokens(tokens) {
+                try {
+                    if (tokens && tokens.access_token) {
+                        localStorage.setItem('aiopicks.traktTokens', JSON.stringify(tokens));
+                    } else {
+                        localStorage.removeItem('aiopicks.traktTokens');
+                    }
+                } catch (err) {
+                    console.warn('Unable to persist Trakt tokens', err);
+                }
+            }
+
+            function readStoredTokens() {
+                try {
+                    const raw = localStorage.getItem('aiopicks.traktTokens');
+                    if (!raw) {
+                        return null;
+                    }
+                    const parsed = JSON.parse(raw);
+                    if (parsed && typeof parsed === 'object') {
+                        return parsed;
+                    }
+                } catch (err) {
+                    console.warn('Unable to read stored Trakt tokens', err);
+                }
+                return null;
+            }
+
+            function showTraktStatus(message, variant) {
+                traktStatus.textContent = message;
+                traktStatus.classList.toggle('success', variant === 'success');
+                traktStatus.classList.toggle('error', variant === 'error');
+                if (variant !== 'success' && variant !== 'error' && message) {
+                    traktStatus.classList.remove('success');
+                    traktStatus.classList.remove('error');
+                }
+                if (!message) {
+                    traktStatus.classList.remove('success');
+                    traktStatus.classList.remove('error');
+                }
+            }
+
+            function showTraktHint(message) {
+                traktHint.textContent = message;
+            }
+
+            function resolveErrorMessage(payload) {
+                if (!payload) {
+                    return null;
+                }
+                if (typeof payload.detail === 'string') {
+                    return payload.detail;
+                }
+                if (payload.detail && typeof payload.detail === 'object') {
+                    return payload.detail.description || payload.detail.error || null;
+                }
+                return payload.message || payload.error_description || payload.error || null;
+            }
+        })();
     </script>
 </body>
 </html>
@@ -723,9 +625,8 @@ def render_config_page(settings: Settings) -> str:
         "catalogCount": settings.catalog_count,
         "refreshIntervalSeconds": settings.refresh_interval_seconds,
         "responseCacheSeconds": settings.response_cache_seconds,
-        "traktClientId": settings.trakt_client_id or "",
         "traktAccessToken": settings.trakt_access_token or "",
-        "traktDeviceAuthEnabled": bool(
+        "traktLoginAvailable": bool(
             settings.trakt_client_id and settings.trakt_client_secret
         ),
     }


### PR DESCRIPTION
## Summary
- add Trakt OAuth authorization endpoint, callback handler, and popup renderer so the server exchanges codes directly
- add a dedicated Trakt authorize URL setting and drop device-code helpers from the configuration UI
- rebuild the `/config` page to prioritise seamless Trakt sign-in and automatically include the issued token when generating manifests

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb1f04bd2083228e1e147a305cc35d