### PR TITLE
Fix Trakt OAuth redirect URI construction

### DIFF
--- a/tests/test_trakt_oauth.py
+++ b/tests/test_trakt_oauth.py
@@ -1,0 +1,66 @@
+"""Tests for the Trakt OAuth helper endpoints."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from urllib.parse import parse_qs, urlparse
+
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.main import CatalogService, create_app
+
+
+@contextmanager
+def _test_client(monkeypatch):
+    monkeypatch.setattr(settings, "trakt_client_id", "client")
+    monkeypatch.setattr(settings, "trakt_client_secret", "secret")
+
+    async def _noop_start(self):  # type: ignore[override]
+        return None
+
+    monkeypatch.setattr(CatalogService, "start", _noop_start)
+
+    app = create_app()
+    with TestClient(app) as client:
+        yield client
+
+
+def _extract_redirect(url: str) -> str:
+    parsed = urlparse(url)
+    params = parse_qs(parsed.query)
+    redirect_values = params.get("redirect_uri")
+    assert redirect_values, "redirect_uri missing from login URL"
+    return redirect_values[0]
+
+
+def test_trakt_login_url_respects_forwarded_proto_and_host(monkeypatch) -> None:
+    with _test_client(monkeypatch) as client:
+        response = client.post(
+            "/api/trakt/login-url",
+            headers={
+                "origin": "https://app.example",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "app.example",
+                "x-forwarded-port": "443",
+            },
+        )
+        assert response.status_code == 200
+        redirect_uri = _extract_redirect(response.json()["url"])
+        assert redirect_uri == "https://app.example/api/trakt/callback"
+
+
+def test_trakt_login_url_honours_forwarded_prefix(monkeypatch) -> None:
+    with _test_client(monkeypatch) as client:
+        response = client.post(
+            "/api/trakt/login-url",
+            headers={
+                "origin": "https://example.com",
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "example.com",
+                "x-forwarded-prefix": "/addon",
+            },
+        )
+        assert response.status_code == 200
+        redirect_uri = _extract_redirect(response.json()["url"])
+        assert redirect_uri == "https://example.com/addon/api/trakt/callback"


### PR DESCRIPTION
## Summary
- ensure Trakt OAuth OAuth redirect URIs are derived from externally visible headers so reverse proxies no longer break the login flow
- preserve the computed redirect/origin during the callback handling
- cover the login URL builder with new pytest cases for forwarded protocol, host and prefix headers

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68cb273804548322b1ee8d78cded8eb1