### PR TITLE
Fix Trakt OAuth redirect origin handling

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -641,14 +641,19 @@ CONFIG_TEMPLATE = dedent(
 )
 
 
-def render_config_page(settings: Settings) -> str:
+def render_config_page(settings: Settings, *, callback_origin: str = "") -> str:
     """Return the full HTML for the `/config` landing page."""
 
-    callback_origin = ""
-    if settings.trakt_redirect_uri:
+    resolved_callback_origin = ""
+    candidate_origin = callback_origin.strip()
+    if candidate_origin:
+        resolved_callback_origin = candidate_origin.rstrip("/")
+    elif settings.trakt_redirect_uri:
         parsed = urlparse(str(settings.trakt_redirect_uri))
         if parsed.scheme and parsed.netloc:
-            callback_origin = f"{parsed.scheme}://{parsed.netloc}".rstrip("/")
+            resolved_callback_origin = (
+                f"{parsed.scheme}://{parsed.netloc}"
+            ).rstrip("/")
 
     defaults = {
         "appName": settings.app_name,
@@ -660,7 +665,7 @@ def render_config_page(settings: Settings) -> str:
         "traktLoginAvailable": bool(
             settings.trakt_client_id and settings.trakt_client_secret
         ),
-        "traktCallbackOrigin": callback_origin,
+        "traktCallbackOrigin": resolved_callback_origin,
     }
     defaults_json = json.dumps(defaults).replace("</", "<\\/")
 

--- a/tests/test_trakt_oauth.py
+++ b/tests/test_trakt_oauth.py
@@ -75,3 +75,17 @@ def test_trakt_login_url_uses_configured_redirect(monkeypatch) -> None:
         assert response.status_code == 200
         redirect_uri = _extract_redirect(response.json()["url"])
         assert redirect_uri == override
+
+
+def test_config_page_includes_callback_origin(monkeypatch) -> None:
+    with _test_client(monkeypatch) as client:
+        response = client.get(
+            "/config",
+            headers={
+                "x-forwarded-proto": "https",
+                "x-forwarded-host": "app.example",
+                "x-forwarded-port": "443",
+            },
+        )
+        assert response.status_code == 200
+        assert "\"traktCallbackOrigin\": \"https://app.example\"" in response.text


### PR DESCRIPTION
## Summary
- derive the Trakt callback origin from the incoming request when rendering the config page so the browser accepts OAuth messages
- reuse the resolved origin when rendering OAuth popup errors to avoid cross-origin postMessage failures
- cover the callback origin propagation with a regression test

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68cba87e87208322a19e648b1df182a7