### PR TITLE
Support profile manifest paths

### DIFF
--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -67,7 +67,16 @@ class ManifestConfig(BaseModel):
 
     @classmethod
     def from_query(cls, params: Mapping[str, str]) -> "ManifestConfig":
-        return cls.model_validate(dict(params))
+        return cls.from_request(params)
+
+    @classmethod
+    def from_request(
+        cls, params: Mapping[str, str], *, profile_id: str | None = None
+    ) -> "ManifestConfig":
+        payload = dict(params)
+        if profile_id is not None:
+            payload["profile"] = profile_id
+        return cls.model_validate(payload)
 
     @field_validator("catalog_count", "refresh_interval", "response_cache", mode="before")
     @classmethod

--- a/app/web.py
+++ b/app/web.py
@@ -777,7 +777,8 @@ CONFIG_TEMPLATE = dedent(
                 const params = new URLSearchParams();
                 const settings = collectManifestSettings();
                 if (profileStatus && profileStatus.profileId) {
-                    params.set('profile', profileStatus.profileId);
+                    const encodedProfileId = encodeURIComponent(profileStatus.profileId);
+                    url.pathname = `/profiles/${encodedProfileId}/manifest.json`;
                 } else if (settings.openrouterKey) {
                     params.set('openrouterKey', settings.openrouterKey);
                 }


### PR DESCRIPTION
## Summary
- add shared helpers to serve manifest, catalog, and meta endpoints with optional profile-aware paths
- expose /profiles/<profile_id> routes so manifest URLs no longer require query parameters
- update the config page preview to generate profile URLs that end with /manifest.json

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_b_68cbbe7da324832291ced2bfbd58871e