### PR TITLE
Advertise only catalog resources in manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ OpenRouter API key, and enjoy endlessly fresh discovery playlists.
 - **OpenRouter AI**: Uses `google/gemini-2.5-flash-lite` for imaginative yet grounded catalog ideas
 - **Randomized Catalogs**: Each refresh injects a random seed so names and picks are always surprising
 - **Privacy-Focused**: All history processing and AI prompts happen on your self-hosted instance
+- **Catalog-Only Manifest**: Advertises just the catalog resource so Stremio can merge in metadata from Cinemeta or other providers you install.
 
 ### 📊 User-Configurable Dynamic Catalogs
 AIOPicks invents themed rows with bespoke names and contents:
@@ -113,7 +114,7 @@ docker run -d \
 
 ## 🏗️ Architecture Overview
 
-- **FastAPI Server** (`app/main.py`): Implements Stremio manifest, catalog, and meta endpoints
+- **FastAPI Server** (`app/main.py`): Implements Stremio manifest and catalog endpoints (metadata endpoint remains available for debugging but is not advertised)
 - **Catalog Service** (`app/services/catalog_generator.py`): Orchestrates Trakt ingestion, AI prompting, caching, and
   background refresh
 - **Trakt Client** (`app/services/trakt.py`): Fetches and summarizes history with optional fallbacks
@@ -128,9 +129,9 @@ interval you configure. If OpenRouter is unavailable, it falls back to simple mi
 
 | Endpoint | Description |
 |----------|-------------|
-| `/manifest.json` | Advertises AI-generated catalogs and metadata to Stremio |
+| `/manifest.json` | Advertises AI-generated catalogs to Stremio (metadata comes from Cinemeta or other addons) |
 | `/catalog/{type}/{id}.json` | Returns the metas array for a specific catalog |
-| `/meta/{type}/{id}.json` | Provides metadata for a specific entry |
+| `/meta/{type}/{id}.json` | (Optional) Internal metadata endpoint for debugging |
 | `/healthz` | Lightweight readiness probe |
 
 ## ⚠️ Disclaimer

--- a/app/main.py
+++ b/app/main.py
@@ -120,7 +120,7 @@ def register_routes(fastapi_app: FastAPI) -> None:
                 "Flash Lite model and your Trakt history."
             ),
             "catalogs": catalogs,
-            "resources": ["catalog", "meta"],
+            "resources": ["catalog"],
             "types": ["movie", "series"],
             "idPrefixes": ["aiopicks", "tt", "trakt"],
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration and test helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Ensure the application package is importable when running tests without an
+# editable install. This mirrors the expected runtime layout where ``app`` sits
+# at the project root.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.main import register_routes
+from app.services.catalog_generator import CatalogService, ManifestConfig
+
+
+class DummyCatalogService(CatalogService):
+    """Minimal CatalogService stub for manifest testing."""
+
+    def __init__(self) -> None:  # pragma: no cover - nothing to initialise
+        # Deliberately skip super().__init__ to avoid touching external systems.
+        pass
+
+    async def list_manifest_catalogs(  # type: ignore[override]
+        self, config: ManifestConfig
+    ) -> tuple[SimpleNamespace, list[dict[str, object]]]:
+        state = SimpleNamespace(openrouter_model="test-model")
+        return state, []
+
+    def profile_id_from_catalog_id(self, catalog_id: str) -> str | None:  # pragma: no cover - not used
+        return None
+
+
+def test_manifest_advertises_only_catalog_resource() -> None:
+    """The manifest should list only catalog resources so Stremio won't request meta."""
+
+    app = FastAPI()
+    register_routes(app)
+    app.state.catalog_service = DummyCatalogService()
+
+    with TestClient(app) as client:
+        response = client.get("/manifest.json")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["resources"] == ["catalog"]


### PR DESCRIPTION
## Summary
- stop advertising the meta resource in the Stremio manifest so the addon can run as catalog-only
- document the catalog-only behavior and clarify that the metadata endpoint is optional
- add a regression test (with pytest bootstrap) to ensure the manifest continues to expose only catalog resources

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cbe2cde6ac8322940667bdf5f9de85