### PR TITLE
Stop exposing metadata responses

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -53,45 +53,6 @@ class CatalogItem(BaseModel):
             "type": self.type,
         }
 
-    def to_meta(self, catalog_id: str, index: int) -> dict[str, object]:
-        """Return a Stremio meta dictionary."""
-
-        meta_id = self.build_meta_id(catalog_id, index)
-
-        meta: dict[str, object] = {
-            "id": meta_id,
-            "type": self.type,
-            "name": self.title,
-        }
-
-        if self.poster:
-            meta["poster"] = str(self.poster)
-        if self.background:
-            meta["background"] = str(self.background)
-        if self.overview:
-            meta["description"] = self.overview
-        if self.year:
-            meta["releaseInfo"] = str(self.year)
-        if self.weight is not None:
-            meta["aiConfidence"] = round(self.weight, 3)
-        if self.genres:
-            meta["genres"] = self.genres
-        if self.runtime_minutes:
-            meta["runtime"] = self.runtime_minutes
-        if self.maturity_rating:
-            meta["contentRating"] = self.maturity_rating
-        if self.providers:
-            meta["links"] = [
-                {"name": provider, "category": "where-to-watch"}
-                for provider in self.providers
-            ]
-
-        meta["behaviorHints"] = {
-            "bingeGroup": catalog_id,
-            "defaultVideoId": meta_id,
-        }
-        return meta
-
 
 class Catalog(BaseModel):
     """Collection of items grouped by the AI."""

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -176,10 +176,6 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
             }
         ]
 
-        meta = await service.find_meta(config, "movie", "tt1234567")
-        assert meta["id"] == "tt1234567"
-        assert meta["name"] == "Sample Movie"
-
         async with database.session_factory() as session:
             stored = await session.get(CatalogRecord, record_id)
             assert stored is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -22,7 +22,9 @@ def test_catalog_from_ai_payload_generates_ids():
     )
 
     assert catalog.id.startswith("aiopicks-movie")
-    assert catalog.items[0].to_meta(catalog.id, 0)["id"] == "tt0359950"
+    stub = catalog.items[0].to_catalog_stub(catalog.id, 0)
+    assert stub["id"] == "tt0359950"
+    assert stub["type"] == "movie"
 
 
 def test_catalog_bundle_from_ai_response_handles_missing_sections():
@@ -51,5 +53,6 @@ def test_catalog_bundle_from_ai_response_handles_missing_sections():
 
 def test_catalog_item_uses_tmdb_id_when_other_ids_missing() -> None:
     item = CatalogItem(title="Example", type="movie", tmdb_id=12345)
-    meta = item.to_meta("aiopicks-movie-demo", 0)
-    assert meta["id"] == "tmdb:12345"
+    stub = item.to_catalog_stub("aiopicks-movie-demo", 0)
+    assert stub["id"] == "tmdb:12345"
+    assert stub["type"] == "movie"


### PR DESCRIPTION
## Summary
- remove the FastAPI `/meta` routes so the addon only exposes catalog resources
- drop metadata-building helpers from the catalog models/service to avoid returning enriched meta
- update the catalog and model tests to cover the catalog-only behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc4e9850dc8322924bc79bec7f3f51