### PR TITLE
Expose metadata details in catalog metas

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -46,12 +46,40 @@ class CatalogItem(BaseModel):
         return ensure_unique_meta_id(base_id, f"{catalog_id}-{self.title}", index)
 
     def to_catalog_stub(self, catalog_id: str, index: int) -> dict[str, object]:
-        """Return a minimal meta entry for catalog listings."""
+        """Return a Stremio-compatible meta object for catalog listings."""
 
-        return {
+        meta: dict[str, object] = {
             "id": self.build_meta_id(catalog_id, index),
             "type": self.type,
         }
+
+        if self.title:
+            meta["name"] = self.title
+        if self.overview:
+            meta["description"] = self.overview
+        if self.poster:
+            meta["poster"] = str(self.poster)
+        if self.background:
+            meta["background"] = str(self.background)
+        if self.year:
+            meta["year"] = self.year
+            meta["releaseInfo"] = str(self.year)
+        if self.weight is not None:
+            meta["popularity"] = self.weight
+        if self.runtime_minutes:
+            meta["runtime"] = self.runtime_minutes
+        if self.genres:
+            meta["genres"] = list(self.genres)
+        if self.maturity_rating:
+            meta["maturityRating"] = self.maturity_rating
+        if self.imdb_id:
+            meta["imdbId"] = self.imdb_id
+        if self.trakt_id:
+            meta["traktId"] = self.trakt_id
+        if self.tmdb_id:
+            meta["tmdbId"] = self.tmdb_id
+
+        return meta
 
 
 class Catalog(BaseModel):

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -173,6 +173,9 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
             {
                 "id": "tt1234567",
                 "type": "movie",
+                "name": "Sample Movie",
+                "description": "A test entry",
+                "imdbId": "tt1234567",
             }
         ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,6 +25,11 @@ def test_catalog_from_ai_payload_generates_ids():
     stub = catalog.items[0].to_catalog_stub(catalog.id, 0)
     assert stub["id"] == "tt0359950"
     assert stub["type"] == "movie"
+    assert stub["name"] == "The Secret Life of Walter Mitty"
+    assert stub["description"] == "A daydreamer's journey"
+    assert stub["poster"] == "https://example.com/poster.jpg"
+    assert stub["imdbId"] == "tt0359950"
+    assert stub["releaseInfo"] == "2013"
 
 
 def test_catalog_bundle_from_ai_response_handles_missing_sections():
@@ -56,3 +61,4 @@ def test_catalog_item_uses_tmdb_id_when_other_ids_missing() -> None:
     stub = item.to_catalog_stub("aiopicks-movie-demo", 0)
     assert stub["id"] == "tmdb:12345"
     assert stub["type"] == "movie"
+    assert stub["tmdbId"] == 12345


### PR DESCRIPTION
## Summary
- include full metadata (name, description, artwork, identifiers) when serialising catalog items for Stremio
- keep catalog responses compatible with existing tests and ensure fallback lookups return enriched metas

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc5379c3f48322a0afeb565b8770dc