### PR TITLE
Return IDs-only catalog stubs

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -53,25 +53,6 @@ class CatalogItem(BaseModel):
             "type": self.type,
         }
 
-        if self.title:
-            meta["name"] = self.title
-        if self.overview:
-            meta["description"] = self.overview
-        if self.poster:
-            meta["poster"] = str(self.poster)
-        if self.background:
-            meta["background"] = str(self.background)
-        if self.year:
-            meta["year"] = self.year
-            meta["releaseInfo"] = str(self.year)
-        if self.weight is not None:
-            meta["popularity"] = self.weight
-        if self.runtime_minutes:
-            meta["runtime"] = self.runtime_minutes
-        if self.genres:
-            meta["genres"] = list(self.genres)
-        if self.maturity_rating:
-            meta["maturityRating"] = self.maturity_rating
         if self.imdb_id:
             meta["imdbId"] = self.imdb_id
         if self.trakt_id:

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -173,8 +173,6 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
             {
                 "id": "tt1234567",
                 "type": "movie",
-                "name": "Sample Movie",
-                "description": "A test entry",
                 "imdbId": "tt1234567",
             }
         ]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,13 +23,11 @@ def test_catalog_from_ai_payload_generates_ids():
 
     assert catalog.id.startswith("aiopicks-movie")
     stub = catalog.items[0].to_catalog_stub(catalog.id, 0)
-    assert stub["id"] == "tt0359950"
-    assert stub["type"] == "movie"
-    assert stub["name"] == "The Secret Life of Walter Mitty"
-    assert stub["description"] == "A daydreamer's journey"
-    assert stub["poster"] == "https://example.com/poster.jpg"
-    assert stub["imdbId"] == "tt0359950"
-    assert stub["releaseInfo"] == "2013"
+    assert stub == {
+        "id": "tt0359950",
+        "type": "movie",
+        "imdbId": "tt0359950",
+    }
 
 
 def test_catalog_bundle_from_ai_response_handles_missing_sections():


### PR DESCRIPTION
## Summary
- only emit ids in catalog meta stubs so that external metadata providers handle artwork and descriptions
- update catalog service and model tests to reflect the trimmed payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc5b83f6988322b6e74787e63c1684