### PR TITLE
Ensure catalog previews expose names and imdb identifiers

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -51,14 +51,17 @@ class CatalogItem(BaseModel):
         meta: dict[str, object] = {
             "id": self.build_meta_id(catalog_id, index),
             "type": self.type,
+            "name": self.title,
         }
 
         if self.imdb_id:
             meta["imdbId"] = self.imdb_id
+            meta["imdb_id"] = self.imdb_id
         if self.trakt_id:
             meta["traktId"] = self.trakt_id
         if self.tmdb_id:
             meta["tmdbId"] = self.tmdb_id
+            meta["tmdb_id"] = self.tmdb_id
 
         return meta
 
@@ -119,6 +122,7 @@ class Catalog(BaseModel):
             "type": self.type,
             "id": self.id,
             "name": self.title,
+            "idProperty": "imdb_id",
             "extra": [],
         }
 

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -173,7 +173,9 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
             {
                 "id": "tt1234567",
                 "type": "movie",
+                "name": "Sample Movie",
                 "imdbId": "tt1234567",
+                "imdb_id": "tt1234567",
             }
         ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -26,7 +26,9 @@ def test_catalog_from_ai_payload_generates_ids():
     assert stub == {
         "id": "tt0359950",
         "type": "movie",
+        "name": "The Secret Life of Walter Mitty",
         "imdbId": "tt0359950",
+        "imdb_id": "tt0359950",
     }
 
 
@@ -60,3 +62,5 @@ def test_catalog_item_uses_tmdb_id_when_other_ids_missing() -> None:
     assert stub["id"] == "tmdb:12345"
     assert stub["type"] == "movie"
     assert stub["tmdbId"] == 12345
+    assert stub["tmdb_id"] == 12345
+    assert stub["name"] == "Example"


### PR DESCRIPTION
## Summary
- include a `name` field and Cinemeta-compatible identifiers on catalog preview items
- advertise `idProperty: imdb_id` in the manifest so Stremio can merge metadata from Cinemeta
- extend tests to cover the new preview shape and identifier fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc6ad160e08322a22458e8e2c51f8b