### PR TITLE
Handle missing names and camelCase identifiers in catalog previews

### DIFF
--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -173,7 +173,9 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
             {
                 "id": "tt1234567",
                 "type": "movie",
+                "name": "Sample Movie",
                 "imdbId": "tt1234567",
+                "imdb_id": "tt1234567",
             }
         ]
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,13 +8,18 @@ def test_catalog_from_ai_payload_generates_ids():
             "description": "Stories to unwind with",
             "items": [
                 {
-                    "name": "The Secret Life of Walter Mitty",
+                    "imdbId": "tt0359950",
                     "type": "movie",
                     "description": "A daydreamer's journey",
                     "poster": "https://example.com/poster.jpg",
                     "year": 2013,
-                    "imdb_id": "tt0359950",
-                }
+                    "name": "The Secret Life of Walter Mitty",
+                },
+                {
+                    "id": "tt0063350",
+                    "type": "movie",
+                    "imdbId": "tt0063350",
+                },
             ],
         },
         content_type="movie",
@@ -26,8 +31,14 @@ def test_catalog_from_ai_payload_generates_ids():
     assert stub == {
         "id": "tt0359950",
         "type": "movie",
+        "name": "The Secret Life of Walter Mitty",
         "imdbId": "tt0359950",
+        "imdb_id": "tt0359950",
     }
+
+    fallback_stub = catalog.items[1].to_catalog_stub(catalog.id, 1)
+    assert fallback_stub["id"] == "tt0063350"
+    assert fallback_stub["name"] == "tt0063350"
 
 
 def test_catalog_bundle_from_ai_response_handles_missing_sections():
@@ -60,3 +71,20 @@ def test_catalog_item_uses_tmdb_id_when_other_ids_missing() -> None:
     assert stub["id"] == "tmdb:12345"
     assert stub["type"] == "movie"
     assert stub["tmdbId"] == 12345
+    assert stub["tmdb_id"] == 12345
+    assert stub["name"] == "Example"
+
+
+def test_catalog_item_uses_identifier_as_fallback_name() -> None:
+    item = CatalogItem(type="movie", imdb_id="tt7654321")
+    stub = item.to_catalog_stub("aiopicks-movie-demo", 0)
+    assert stub["name"] == "tt7654321"
+    assert item.display_name() == "tt7654321"
+
+
+def test_catalog_item_accepts_camel_case_ids() -> None:
+    item = CatalogItem.model_validate(
+        {"type": "movie", "name": "Sample", "traktId": 42, "tmdbId": 123}
+    )
+    assert item.trakt_id == 42
+    assert item.tmdb_id == 123


### PR DESCRIPTION
## Summary
- allow `CatalogItem` to populate camelCase identifier fields and backfill missing titles from identifiers
- expose a reusable display-name fallback for catalog stubs so Stremio still receives non-empty names
- extend model tests to cover identifier-derived titles and camelCase parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc6ad160e08322a22458e8e2c51f8b