### PR TITLE
Ensure catalog previews expose titles for Stremio

### DIFF
--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -64,3 +64,10 @@ def test_catalog_item_uses_tmdb_id_when_other_ids_missing() -> None:
     assert stub["tmdbId"] == 12345
     assert stub["tmdb_id"] == 12345
     assert stub["name"] == "Example"
+
+
+def test_catalog_item_stub_falls_back_to_id_for_blank_title() -> None:
+    item = CatalogItem(title="  ", type="movie", imdb_id="tt7654321")
+    stub = item.to_catalog_stub("aiopicks-movie-demo", 0)
+    assert stub["id"] == "tt7654321"
+    assert stub["name"] == "tt7654321"


### PR DESCRIPTION
## Summary
- ensure catalog preview objects always expose a usable `name` by falling back to known IDs when the AI omits a title
- use the derived display title when building unique meta IDs so blank titles still yield deterministic identifiers
- add coverage to guarantee previews with blank titles still surface an IMDb fallback name

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc7139bf648322911cec3a17bd8460