### PR TITLE
Add server-side Cinemeta enrichment for catalog previews

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,6 +50,9 @@ class Settings(BaseSettings):
     openrouter_api_url: HttpUrl = Field(
         default="https://openrouter.ai/api/v1", alias="OPENROUTER_API_URL"
     )
+    cinemeta_api_url: HttpUrl = Field(
+        default="https://v3-cinemeta.strem.io", alias="CINEMETA_API_URL"
+    )
 
     database_url: str = Field(
         default="sqlite+aiosqlite:///./aiopicks.db", alias="DATABASE_URL"

--- a/app/models.py
+++ b/app/models.py
@@ -71,6 +71,15 @@ class CatalogItem(BaseModel):
             "name": self.display_title(),
         }
 
+        if self.overview:
+            meta["description"] = self.overview
+        if self.poster:
+            meta["poster"] = str(self.poster)
+        if self.background:
+            meta["background"] = str(self.background)
+        if self.year:
+            meta["year"] = self.year
+
         if self.imdb_id:
             meta["imdbId"] = self.imdb_id
             meta["imdb_id"] = self.imdb_id

--- a/app/services/cinemeta.py
+++ b/app/services/cinemeta.py
@@ -1,0 +1,170 @@
+"""Helper client for fetching metadata from Cinemeta."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+import httpx
+
+from ..config import Settings
+from ..utils import slugify
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class CinemetaMatch:
+    """Represents the useful fields returned from a Cinemeta search."""
+
+    id: str
+    title: str
+    type: str
+    year: int | None = None
+    poster: str | None = None
+    background: str | None = None
+
+
+class CinemetaClient:
+    """Wrapper around Cinemeta's catalog search endpoints."""
+
+    _SEARCH_PATH = "/catalog/{type}/top/search={query}.json"
+
+    def __init__(self, settings: Settings, http_client: httpx.AsyncClient):
+        self._settings = settings
+        self._client = http_client
+        self._semaphore = asyncio.Semaphore(8)
+
+    async def lookup(
+        self, title: str, *, content_type: str, year: int | None = None
+    ) -> CinemetaMatch | None:
+        """Return the best Cinemeta match for the given title/year."""
+
+        normalized_title = (title or "").strip()
+        if not normalized_title:
+            return None
+
+        path = self._SEARCH_PATH.format(
+            type=content_type,
+            query=quote(normalized_title, safe=""),
+        )
+
+        try:
+            async with self._semaphore:
+                response = await self._client.get(path)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            logger.warning("Cinemeta lookup failed for %s: %s", normalized_title, exc)
+            return None
+
+        payload = response.json()
+        metas = payload.get("metas") or []
+        if not isinstance(metas, list) or not metas:
+            return None
+
+        match = self._select_best_match(normalized_title, year, metas, content_type)
+        if match is None:
+            return None
+
+        candidate_year = self._parse_year(match.get("releaseInfo") or match.get("year"))
+        poster = self._ensure_url(match.get("poster") or match.get("thumbnail"))
+        background = self._ensure_url(match.get("background") or match.get("fanart"))
+        match_id = str(match.get("imdb_id") or match.get("id") or "").strip()
+        if not match_id:
+            return None
+
+        return CinemetaMatch(
+            id=match_id,
+            title=str(match.get("name") or normalized_title),
+            type=str(match.get("type") or content_type),
+            year=candidate_year,
+            poster=poster,
+            background=background,
+        )
+
+    def _select_best_match(
+        self,
+        title: str,
+        year: int | None,
+        metas: list[Any],
+        content_type: str,
+    ) -> dict[str, Any] | None:
+        candidates: list[dict[str, Any]] = [
+            meta for meta in metas if isinstance(meta, dict)
+        ]
+        if not candidates:
+            return None
+
+        target_slug = slugify(title)
+
+        def candidate_year(meta: dict[str, Any]) -> int | None:
+            return self._parse_year(meta.get("releaseInfo") or meta.get("year"))
+
+        exact_year_matches = [
+            meta
+            for meta in candidates
+            if slugify(str(meta.get("name") or "")) == target_slug
+            and year is not None
+            and candidate_year(meta) == year
+        ]
+        if exact_year_matches:
+            return exact_year_matches[0]
+
+        exact_title_matches = [
+            meta
+            for meta in candidates
+            if slugify(str(meta.get("name") or "")) == target_slug
+        ]
+        if year is not None and exact_title_matches:
+            exact_title_matches.sort(
+                key=lambda meta: self._year_delta(candidate_year(meta), year)
+            )
+            return exact_title_matches[0]
+
+        if year is not None:
+            scored = sorted(
+                candidates,
+                key=lambda meta: self._year_delta(candidate_year(meta), year),
+            )
+            best = scored[0]
+            if candidate_year(best) is not None:
+                return best
+
+        if exact_title_matches:
+            return exact_title_matches[0]
+
+        return candidates[0]
+
+    @staticmethod
+    def _year_delta(candidate: int | None, target: int) -> int:
+        if candidate is None:
+            return 1_000
+        return abs(candidate - target)
+
+    @staticmethod
+    def _parse_year(value: Any) -> int | None:
+        if isinstance(value, int):
+            return value
+        if not value:
+            return None
+        text = str(value)
+        match = re.search(r"(19|20|21)\d{2}", text)
+        if not match:
+            return None
+        try:
+            year = int(match.group(0))
+        except ValueError:
+            return None
+        if 1900 <= year <= 2100:
+            return year
+        return None
+
+    @staticmethod
+    def _ensure_url(value: Any) -> str | None:
+        if isinstance(value, str) and value.startswith("http"):
+            return value
+        return None

--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -33,10 +33,10 @@ Trakt profile summary (generated at {generated_at} UTC):
 Instructions:
 1. Generate {catalog_count} movie catalogs AND {catalog_count} series catalogs.
 2. Use the random seed `{seed}` to introduce surprise (shuffle titles, invent novel themes).
-3. Each catalog must include 6-10 strong picks with real-world metadata.
+3. Each catalog must include 6-10 strong picks with real titles and release years.
 4. Avoid repeating catalog titles across refreshes by choosing unexpected phrasing.
 5. Balance comfort picks (known favorites) with 30% exploratory discoveries.
-6. Provide diverse posters/backgrounds when possible and include imdb or trakt IDs when you know them.
+6. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with Cinemeta.
 
 Respond with JSON using this structure:
 {{
@@ -50,18 +50,8 @@ Respond with JSON using this structure:
         {{
           "name": "Movie title",
           "type": "movie",
-          "description": "short synopsis",
-          "poster": "https://...",
-          "background": "https://...",
           "year": 2024,
-          "imdb_id": "tt...",
-          "trakt_id": 12345,
-          "tmdb_id": 67890,
-          "runtime_minutes": 120,
-          "genres": ["genre"],
-          "maturity_rating": "PG-13",
-          "weight": 0.0,
-          "providers": ["Netflix", "Hulu"]
+          "description": "short synopsis"
         }}
       ]
     }}

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -8,6 +8,7 @@ from app.config import Settings
 from app.database import Database
 from app.db_models import CatalogRecord, Profile
 from app.models import Catalog, CatalogItem
+from app.services.cinemeta import CinemetaClient
 from app.services.catalog_generator import CatalogService
 from app.services.catalog_generator import ProfileState, ProfileStatus
 from app.services.openrouter import OpenRouterClient
@@ -30,6 +31,7 @@ def test_default_profile_skipped_without_api_key(tmp_path) -> None:
             settings,
             cast(TraktClient, object()),
             cast(OpenRouterClient, object()),
+            cast(CinemetaClient, object()),
             database.session_factory,
         )
 
@@ -89,6 +91,7 @@ def test_profile_id_inferred_from_catalog_id() -> None:
         settings,
         cast(TraktClient, object()),
         cast(OpenRouterClient, object()),
+        cast(CinemetaClient, object()),
         cast(Database, object()),  # session factory not needed for this test
     )
 
@@ -110,6 +113,7 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
             settings,
             cast(TraktClient, object()),
             cast(OpenRouterClient, object()),
+            cast(CinemetaClient, object()),
             database.session_factory,
         )
 
@@ -174,6 +178,7 @@ def test_catalog_lookup_falls_back_to_any_profile(tmp_path) -> None:
                 "id": "tt1234567",
                 "type": "movie",
                 "name": "Sample Movie",
+                "description": "A test entry",
                 "imdbId": "tt1234567",
                 "imdb_id": "tt1234567",
             }

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -27,6 +27,9 @@ def test_catalog_from_ai_payload_generates_ids():
         "id": "tt0359950",
         "type": "movie",
         "name": "The Secret Life of Walter Mitty",
+        "description": "A daydreamer's journey",
+        "poster": "https://example.com/poster.jpg",
+        "year": 2013,
         "imdbId": "tt0359950",
         "imdb_id": "tt0359950",
     }


### PR DESCRIPTION
## Summary
- add a Cinemeta client and call it during catalog refreshes to backfill imdb ids and artwork for AI generated items
- expose the Cinemeta base URL in settings and initialise the client during app startup
- emit richer catalog stubs, adjust the OpenRouter prompt, and update unit tests for the new metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc7cd6aa3083229dda7500c09f8cdb