### PR TITLE
Refresh config UI and allow custom manifest name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ AIOPicks invents themed rows with bespoke names and contents:
 
 ### 🧰 Flexible Configuration
 - **Catalog Count**: Choose how many movie/series rows to generate (1-12)
+- **Manifest Name**: Override the add-on title shown inside Stremio without exposing model details
 - **Refresh Interval**: Control how often the AI regenerates catalogs
 - **Caching**: Lightweight in-memory cache keeps Stremio responses snappy between refreshes
 - **Fallbacks**: If the AI call fails, the addon gracefully falls back to history-based mixes

--- a/app/main.py
+++ b/app/main.py
@@ -117,11 +117,13 @@ def register_routes(fastapi_app: FastAPI) -> None:
             profile_state, catalogs = await service.list_manifest_catalogs(config)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        name_suffix = profile_state.openrouter_model
+        manifest_name = (config.manifest_name or "").strip()
+        if not manifest_name:
+            manifest_name = settings.app_name
         return {
             "id": "com.aiopicks.python",
             "version": "1.0.0",
-            "name": f"{settings.app_name} ({name_suffix})",
+            "name": manifest_name,
             "description": (
                 "Dynamic, AI-randomized catalogs powered by OpenRouter's Google Gemini 2.5 "
                 "Flash Lite model and your Trakt history."

--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -41,6 +41,11 @@ class ManifestConfig(BaseModel):
         default=None,
         validation_alias=AliasChoices("openrouterModel", "openRouterModel"),
     )
+    manifest_name: str | None = Field(
+        default=None,
+        max_length=120,
+        validation_alias=AliasChoices("manifestName", "addonName"),
+    )
     catalog_count: int | None = Field(
         default=None,
         ge=1,
@@ -109,6 +114,7 @@ class ManifestConfig(BaseModel):
         "profile_id",
         "openrouter_key",
         "openrouter_model",
+        "manifest_name",
         "trakt_client_id",
         "trakt_access_token",
         mode="before",

--- a/app/web.py
+++ b/app/web.py
@@ -21,8 +21,30 @@ CONFIG_TEMPLATE = dedent(
         :root {
             color-scheme: light dark;
             font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
-            background: #020617;
-            color: #e2e8f0;
+            --surface: #ffffff;
+            --surface-muted: #f4f4f5;
+            --surface-strong: #e4e4e7;
+            --text-primary: #1f2933;
+            --text-muted: #6b7280;
+            --outline: #d4d4d8;
+            --outline-strong: #b4b4be;
+            --accent: #2f2f37;
+            --accent-contrast: #f9fafb;
+            background: var(--surface-muted);
+            color: var(--text-primary);
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --surface: rgba(24, 24, 27, 0.82);
+                --surface-muted: rgba(39, 39, 42, 0.8);
+                --surface-strong: rgba(63, 63, 70, 0.65);
+                --text-primary: #e5e7eb;
+                --text-muted: #a1a1aa;
+                --outline: rgba(82, 82, 91, 0.65);
+                --outline-strong: rgba(113, 113, 122, 0.75);
+                --accent: #f4f4f5;
+                --accent-contrast: #111827;
+            }
         }
         * {
             box-sizing: border-box;
@@ -30,12 +52,12 @@ CONFIG_TEMPLATE = dedent(
         body {
             margin: 0;
             min-height: 100vh;
-            background: radial-gradient(circle at top, rgba(30,64,175,0.35), transparent 55%),
-                        radial-gradient(circle at 20% 60%, rgba(14,165,233,0.18), transparent 55%),
-                        #020617;
+            background: var(--surface-muted);
         }
         a {
-            color: #38bdf8;
+            color: inherit;
+            text-decoration: underline;
+            text-decoration-color: var(--outline-strong);
         }
         main {
             max-width: 960px;
@@ -54,28 +76,28 @@ CONFIG_TEMPLATE = dedent(
         header p {
             margin: 0 auto;
             max-width: 640px;
-            color: rgba(226,232,240,0.82);
+            color: var(--text-muted);
         }
         .grid {
             display: grid;
             gap: 1.75rem;
         }
         .card {
-            background: rgba(15,23,42,0.82);
-            border: 1px solid rgba(148,163,184,0.15);
+            background: var(--surface);
+            border: 1px solid var(--outline);
             border-radius: 20px;
             padding: 1.75rem;
-            box-shadow: 0 25px 50px -12px rgba(15,23,42,0.45);
-            backdrop-filter: blur(18px);
+            box-shadow: 0 24px 40px -28px rgba(17, 24, 39, 0.35);
+            backdrop-filter: blur(10px);
         }
         .card h2 {
             margin-top: 0;
-            font-size: 1.4rem;
+            font-size: 1.35rem;
             margin-bottom: 0.75rem;
         }
         .card p.description {
             margin-top: 0;
-            color: rgba(226,232,240,0.72);
+            color: var(--text-muted);
             margin-bottom: 1.25rem;
         }
         .field {
@@ -84,32 +106,34 @@ CONFIG_TEMPLATE = dedent(
         .field label {
             display: flex;
             justify-content: space-between;
+            gap: 1rem;
             font-weight: 600;
             font-size: 0.95rem;
             margin-bottom: 0.35rem;
-            color: rgba(226,232,240,0.88);
+            color: var(--text-primary);
         }
         .field label span.helper {
             font-weight: 400;
             font-size: 0.85rem;
-            color: rgba(148,163,184,0.92);
+            color: var(--text-muted);
         }
         input[type="text"],
         select {
             width: 100%;
-            background: rgba(15,23,42,0.95);
-            border: 1px solid rgba(148,163,184,0.25);
+            background: var(--surface-muted);
+            border: 1px solid var(--outline);
             border-radius: 12px;
-            color: #e2e8f0;
+            color: var(--text-primary);
             padding: 0.65rem 0.85rem;
             font-size: 1rem;
-            transition: border 0.2s ease, box-shadow 0.2s ease;
+            transition: border 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
         }
         input[type="text"]:focus,
         select:focus {
             outline: none;
-            border-color: rgba(129,140,248,0.8);
-            box-shadow: 0 0 0 3px rgba(129,140,248,0.2);
+            border-color: var(--outline-strong);
+            box-shadow: 0 0 0 3px rgba(148, 148, 160, 0.25);
+            background: var(--surface);
         }
         input[type="range"] {
             width: 100%;
@@ -128,72 +152,81 @@ CONFIG_TEMPLATE = dedent(
             appearance: none;
             border: none;
             border-radius: 999px;
-            padding: 0.65rem 1.25rem;
-            background: linear-gradient(120deg, #6366f1, #8b5cf6);
-            color: white;
+            padding: 0.65rem 1.35rem;
+            background: linear-gradient(120deg, var(--accent), #3f3f46);
+            color: var(--accent-contrast);
             font-weight: 600;
             font-size: 0.95rem;
             cursor: pointer;
             transition: transform 0.15s ease, box-shadow 0.2s ease, filter 0.2s ease;
         }
         button.secondary {
-            background: rgba(30,41,59,0.9);
-            border: 1px solid rgba(148,163,184,0.25);
+            background: transparent;
+            color: var(--text-primary);
+            border: 1px solid var(--outline-strong);
         }
         button:hover:not(:disabled) {
             transform: translateY(-1px);
-            box-shadow: 0 10px 25px rgba(99,102,241,0.35);
+            box-shadow: 0 12px 24px -18px rgba(17, 24, 39, 0.35);
         }
         button:disabled {
             cursor: not-allowed;
             opacity: 0.6;
+            box-shadow: none;
         }
         .muted {
             font-size: 0.85rem;
-            color: rgba(148,163,184,0.9);
+            color: var(--text-muted);
         }
         .notice {
             margin-bottom: 1rem;
             padding: 0.75rem 1rem;
             border-radius: 14px;
-            background: rgba(15,23,42,0.9);
-            border: 1px dashed rgba(148,163,184,0.35);
-            color: rgba(226,232,240,0.88);
+            background: var(--surface-muted);
+            border: 1px dashed var(--outline);
+            color: var(--text-primary);
         }
         .status {
             margin-top: 0.85rem;
             font-size: 0.95rem;
-            color: rgba(226,232,240,0.92);
+            color: var(--text-primary);
             min-height: 1.2em;
+            padding: 0.4rem 0.6rem;
+            border-radius: 10px;
+            background: transparent;
         }
         .status.error {
-            color: #fca5a5;
+            background: var(--surface-muted);
+            border-left: 4px solid var(--outline-strong);
         }
         .status.success {
-            color: #86efac;
+            background: var(--surface-muted);
+            border-left: 4px solid var(--outline);
         }
         .preview {
-            background: rgba(15,23,42,0.9);
-            border: 1px dashed rgba(148,163,184,0.3);
+            background: var(--surface-muted);
+            border: 1px dashed var(--outline);
             border-radius: 14px;
             padding: 0.9rem 1rem;
             margin-top: 1rem;
             font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, monospace;
             font-size: 0.9rem;
             word-break: break-all;
-            color: rgba(226,232,240,0.9);
+            color: var(--text-primary);
         }
         .pill {
             display: inline-flex;
             align-items: center;
             gap: 0.5rem;
-            background: rgba(30,41,59,0.95);
-            border: 1px solid rgba(148,163,184,0.25);
+            background: var(--surface-muted);
+            border: 1px solid var(--outline);
             border-radius: 999px;
             padding: 0.35rem 0.75rem;
             font-size: 0.85rem;
             font-weight: 600;
-            color: rgba(226,232,240,0.9);
+            color: var(--text-muted);
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
         }
         .hidden {
             display: none !important;
@@ -212,12 +245,12 @@ CONFIG_TEMPLATE = dedent(
         }
     </style>
 </head>
-<body>
-    <main>
-        <header>
-            <p class="pill">Stremio Add-on • __OPENROUTER_MODEL__</p>
+    <body>
+        <main>
+            <header>
+            <p class="pill">Stremio Add-on</p>
             <h1>Configure __APP_NAME__</h1>
-            <p>Connect your Trakt account and generate a personalised manifest link for Stremio.</p>
+            <p>Connect your Trakt account, fine-tune the manifest name, and copy an install-ready link for Stremio.</p>
         </header>
         <div class="grid">
             <section class="card" id="trakt-card">
@@ -232,8 +265,12 @@ CONFIG_TEMPLATE = dedent(
             </section>
             <section class="card" id="manifest-card">
                 <h2>Manifest builder</h2>
-                <p class="description">Choose how many AI generated catalogs to expose and copy a ready-to-install manifest URL. Empty fields fall back to the server defaults.</p>
+                <p class="description">Choose how many AI generated catalogs to expose, set the display name, and copy a ready-to-install manifest URL. Empty fields fall back to the server defaults.</p>
                 <p class="notice hidden" id="manifest-lock">Sign in with Trakt to unlock personalised manifest links.</p>
+                <div class="field">
+                    <label for="config-manifest-name">Add-on name <span class="helper">Defaults to __APP_NAME__</span></label>
+                    <input id="config-manifest-name" type="text" placeholder="Add-on name as seen in Stremio" maxlength="120" />
+                </div>
                 <div class="field">
                     <label for="config-openrouter-key">OpenRouter API key <span class="helper">Optional – stored client side only</span></label>
                     <input id="config-openrouter-key" type="text" placeholder="sk-or-..." autocomplete="off" spellcheck="false" />
@@ -251,7 +288,7 @@ CONFIG_TEMPLATE = dedent(
                     <input id="config-catalog-items" type="range" min="4" max="100" step="1" />
                 </div>
                 <div class="field">
-                    <label for="config-refresh-interval">Refresh cadence <span class="helper">How often Gemini rethinks the catalogs</span></label>
+                    <label for="config-refresh-interval">Refresh cadence <span class="helper">How often the AI rethinks the catalogs</span></label>
                     <select id="config-refresh-interval">
                         <option value="3600">Every hour</option>
                         <option value="14400">Every 4 hours</option>
@@ -283,7 +320,9 @@ CONFIG_TEMPLATE = dedent(
         (function () {
             const defaults = JSON.parse('__DEFAULTS_JSON__');
             const baseManifestUrl = new URL('/manifest.json', window.location.origin).toString();
+            const defaultManifestName = (defaults.manifestName || defaults.appName || '').trim();
 
+            const manifestNameInput = document.getElementById('config-manifest-name');
             const openrouterKey = document.getElementById('config-openrouter-key');
             const openrouterModel = document.getElementById('config-openrouter-model');
             const catalogSlider = document.getElementById('config-catalog-count');
@@ -318,6 +357,7 @@ CONFIG_TEMPLATE = dedent(
             let profileStatus = null;
             let statusPollTimer = null;
 
+            manifestNameInput.value = defaultManifestName;
             openrouterModel.value = defaults.openrouterModel || '';
             catalogSlider.value = defaults.catalogCount || catalogSlider.min || 1;
             catalogValue.textContent = catalogSlider.value;
@@ -345,6 +385,11 @@ CONFIG_TEMPLATE = dedent(
                 if (status && status.refreshing) {
                     scheduleStatusPoll();
                 }
+            });
+
+            manifestNameInput.addEventListener('input', () => {
+                markProfileDirty();
+                updateManifestPreview();
             });
 
             catalogSlider.addEventListener('input', () => {
@@ -662,7 +707,12 @@ CONFIG_TEMPLATE = dedent(
             }
 
             function collectManifestSettings() {
+                const trimmedManifestName = manifestNameInput.value.trim();
                 return {
+                    manifestName:
+                        trimmedManifestName && trimmedManifestName !== defaultManifestName
+                            ? trimmedManifestName
+                            : '',
                     openrouterKey: openrouterKey.value.trim(),
                     openrouterModel: openrouterModel.value.trim(),
                     catalogCount: catalogSlider.value,
@@ -680,6 +730,7 @@ CONFIG_TEMPLATE = dedent(
                 if (includeProfileId && profileStatus && profileStatus.profileId) {
                     payload.profileId = profileStatus.profileId;
                 }
+                if (settings.manifestName) payload.manifestName = settings.manifestName;
                 if (settings.openrouterKey) payload.openrouterKey = settings.openrouterKey;
                 if (settings.openrouterModel) payload.openrouterModel = settings.openrouterModel;
                 if (settings.catalogCount) payload.catalogCount = Number(settings.catalogCount);
@@ -798,6 +849,7 @@ CONFIG_TEMPLATE = dedent(
                 } else if (settings.openrouterKey) {
                     params.set('openrouterKey', settings.openrouterKey);
                 }
+                if (settings.manifestName) params.set('manifestName', settings.manifestName);
                 if (settings.openrouterModel) params.set('openrouterModel', settings.openrouterModel);
                 if (settings.catalogCount) params.set('catalogCount', settings.catalogCount);
                 if (settings.catalogItems) params.set('catalogItems', settings.catalogItems);
@@ -996,6 +1048,7 @@ def render_config_page(settings: Settings, *, callback_origin: str = "") -> str:
 
     defaults = {
         "appName": settings.app_name,
+        "manifestName": settings.app_name,
         "openrouterModel": settings.openrouter_model,
         "catalogCount": settings.catalog_count,
         "catalogItemCount": settings.catalog_item_count,


### PR DESCRIPTION
## Summary
- restyle the configuration page with a neutral theme and new add-on name control
- let manifest responses honour an optional `manifestName` instead of appending the model name
- document the ability to override the Stremio display name in the README

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc88242ee483229f64dbeabe3d7a94