### PR TITLE
Improve catalog prompt personalization

### DIFF
--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -36,9 +36,10 @@ Instructions:
 2. Use the random seed `{seed}` to introduce surprise (shuffle titles, invent novel themes).
 3. Each catalog must include EXACTLY {items_per_catalog} strong picks with real titles and release years.
 4. Keep each description to a single crisp sentence (max ~16 words) to conserve tokens, even when {items_per_catalog} is large.
-5. Avoid repeating catalog titles across refreshes by choosing unexpected phrasing.
-6. Balance comfort picks (known favorites) with 30% exploratory discoveries.
-7. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with Cinemeta.
+5. Craft each catalog title as a premium streaming row tailored to this profile—reference the viewer's top genres, languages, or recent watches so it feels handpicked.
+6. Write titles in natural sentence case (capitalize the first word and proper nouns only) and avoid bland or generic phrasing.
+7. Balance comfort picks (known favorites) with 30% exploratory discoveries, highlighting why each row will delight this viewer.
+8. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with Cinemeta.
 
 Respond with JSON using this structure:
 {{


### PR DESCRIPTION
## Summary
- enhance the OpenRouter instructions so catalog titles lean on the viewer's logged tastes
- require sentence-case, premium-quality themes while keeping descriptions concise and balanced

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cc9c8d7d308322922278c39566a6d3