### PR TITLE
Allow configurable metadata add-on

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from typing import Literal
 
-from pydantic import Field, HttpUrl
+from pydantic import AliasChoices, Field, HttpUrl
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -53,8 +53,10 @@ class Settings(BaseSettings):
     openrouter_api_url: HttpUrl = Field(
         default="https://openrouter.ai/api/v1", alias="OPENROUTER_API_URL"
     )
-    cinemeta_api_url: HttpUrl = Field(
-        default="https://v3-cinemeta.strem.io", alias="CINEMETA_API_URL"
+    metadata_addon_url: HttpUrl | None = Field(
+        default=None,
+        alias="METADATA_ADDON_URL",
+        validation_alias=AliasChoices("METADATA_ADDON_URL", "CINEMETA_API_URL"),
     )
 
     database_url: str = Field(
@@ -64,6 +66,12 @@ class Settings(BaseSettings):
     environment: Literal["development", "production"] = Field(
         default="development", alias="ENVIRONMENT"
     )
+
+    @property
+    def cinemeta_api_url(self) -> HttpUrl | None:
+        """Maintain backwards compatibility with the previous setting name."""
+
+        return self.metadata_addon_url
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -25,6 +25,7 @@ class Profile(Base):
     catalog_item_count: Mapped[int] = mapped_column(Integer, default=8)
     refresh_interval_seconds: Mapped[int] = mapped_column(Integer, default=43_200)
     response_cache_seconds: Mapped[int] = mapped_column(Integer, default=1_800)
+    metadata_addon_url: Mapped[str | None] = mapped_column(String(512), nullable=True)
     next_refresh_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     last_refreshed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(


### PR DESCRIPTION
## Summary
- make the metadata add-on URL configurable via settings and persisted per profile
- only enrich catalogs when a metadata provider is available and normalize add-on URLs
- expose a metadata add-on field in the config UI and include it in generated manifest links
- cover the new profile persistence behavior with a unit test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd7e88a0ac8322b96e3f0532497fe5