### PR TITLE
feat: expose Trakt history depth controls

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,8 @@ OPENROUTER_MODEL=google/gemini-2.5-flash-lite
 TRAKT_CLIENT_ID=replace-with-trakt-client-id
 TRAKT_CLIENT_SECRET=replace-with-trakt-client-secret
 TRAKT_ACCESS_TOKEN=replace-with-trakt-access-token
+# Increase if you want deeper history exclusion
+TRAKT_HISTORY_LIMIT=1000
 # Optional: override the detected redirect URL if proxying through a custom domain
 TRAKT_REDIRECT_URI=https://your-domain.example/api/trakt/callback
 CATALOG_COUNT=6

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ AIOPicks invents themed rows with bespoke names and contents:
 - **Catalog Count**: Choose how many movie/series rows to generate (1-12)
 - **Manifest Name**: Override the add-on title shown inside Stremio without exposing model details
 - **Refresh Interval**: Control how often the AI regenerates catalogs
+- **History Depth**: Decide how many of your recent Trakt plays (up to 2,000) are used to avoid repeats
 - **Caching**: Lightweight in-memory cache keeps Stremio responses snappy between refreshes
 - **Fallbacks**: If the AI call fails, the addon gracefully falls back to history-based mixes
 

--- a/app/config.py
+++ b/app/config.py
@@ -24,7 +24,9 @@ class Settings(BaseSettings):
     trakt_redirect_uri: HttpUrl | None = Field(
         default=None, alias="TRAKT_REDIRECT_URI"
     )
-    trakt_history_limit: int = Field(default=500, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000)
+    trakt_history_limit: int = Field(
+        default=1_000, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000
+    )
 
     openrouter_api_key: str | None = Field(
         default=None, alias="OPENROUTER_API_KEY"

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -21,6 +21,12 @@ class Profile(Base):
     openrouter_model: Mapped[str] = mapped_column(String(200))
     trakt_client_id: Mapped[str | None] = mapped_column(String(200), nullable=True)
     trakt_access_token: Mapped[str | None] = mapped_column(String(200), nullable=True)
+    trakt_history_limit: Mapped[int] = mapped_column(Integer, default=1_000)
+    trakt_movie_history_count: Mapped[int] = mapped_column(Integer, default=0)
+    trakt_show_history_count: Mapped[int] = mapped_column(Integer, default=0)
+    trakt_history_refreshed_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )
     catalog_count: Mapped[int] = mapped_column(Integer, default=6)
     catalog_item_count: Mapped[int] = mapped_column(Integer, default=8)
     refresh_interval_seconds: Mapped[int] = mapped_column(Integer, default=43_200)


### PR DESCRIPTION
## Summary
- raise the default Trakt history depth to 1,000 plays and persist it per profile
- surface Trakt movie/show counts on the config page with a configurable history slider
- cache and periodically refresh Trakt history statistics while keeping the database schema up to date

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd8d337a0c83229a94d69a64f7cec3