### PR TITLE
Fix Trakt stats aggregation and surface richer UI summaries

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -87,6 +87,10 @@ class Database:
             "trakt_history_refreshed_at",
             "ALTER TABLE profiles ADD COLUMN trakt_history_refreshed_at DATETIME",
         )
+        _ensure_column(
+            "trakt_history_snapshot",
+            "ALTER TABLE profiles ADD COLUMN trakt_history_snapshot JSON",
+        )
 
     async def dispose(self) -> None:
         """Dispose of the underlying database engine."""

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -26,6 +27,9 @@ class Profile(Base):
     trakt_show_history_count: Mapped[int] = mapped_column(Integer, default=0)
     trakt_history_refreshed_at: Mapped[datetime | None] = mapped_column(
         DateTime, nullable=True
+    )
+    trakt_history_snapshot: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
     )
     catalog_count: Mapped[int] = mapped_column(Integer, default=6)
     catalog_item_count: Mapped[int] = mapped_column(Integer, default=8)


### PR DESCRIPTION
## Summary
- query the Trakt `/users/me/stats` endpoint to capture accurate watch totals and minutes
- persist a rich history snapshot on profiles and expose the data to the configuration UI
- update the front-end stats block to show lifetime counts, plays and watch time, plus add coverage for the new helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdb029579c8322b78f88158482efa2