### PR TITLE
Use slash-delimited manifest overrides

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -117,7 +117,13 @@ def register_routes(fastapi_app: FastAPI) -> None:
     ) -> dict[str, Any]:
         service = get_catalog_service(fastapi_app)
         try:
-            payload = dict(request.query_params)
+            query_params = dict(request.query_params)
+            if query_params:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Query parameters are not supported for manifest overrides.",
+                )
+            payload: dict[str, str] = {}
             if extra_params:
                 payload.update(extra_params)
             config = ManifestConfig.from_request(payload, profile_id=profile_id)

--- a/app/web.py
+++ b/app/web.py
@@ -1012,27 +1012,38 @@ CONFIG_TEMPLATE = dedent(
 
             function buildConfiguredUrl() {
                 const url = new URL(baseManifestUrl);
-                const params = new URLSearchParams();
+                url.search = '';
                 const settings = collectManifestSettings();
                 if (profileStatus && profileStatus.profileId) {
                     const encodedProfileId = encodeURIComponent(profileStatus.profileId);
                     url.pathname = `/profiles/${encodedProfileId}/manifest.json`;
-                } else if (settings.openrouterKey) {
-                    params.set('openrouterKey', settings.openrouterKey);
+                    return url.toString();
                 }
-                if (settings.openrouterModel) params.set('openrouterModel', settings.openrouterModel);
-                if (settings.catalogCount) params.set('catalogCount', settings.catalogCount);
-                if (settings.catalogItems) params.set('catalogItems', settings.catalogItems);
-                if (settings.traktHistoryLimit) {
-                    params.set('traktHistoryLimit', settings.traktHistoryLimit);
+                const manifestKeys = [
+                    'openrouterKey',
+                    'openrouterModel',
+                    'metadataAddon',
+                    'catalogCount',
+                    'catalogItems',
+                    'traktHistoryLimit',
+                    'refreshInterval',
+                    'cacheTtl',
+                    'traktAccessToken',
+                ];
+                const segments = [];
+                manifestKeys.forEach((key) => {
+                    const value = settings[key];
+                    if (!value) {
+                        return;
+                    }
+                    segments.push(encodeURIComponent(key));
+                    segments.push(encodeURIComponent(String(value)));
+                });
+                if (segments.length > 0) {
+                    url.pathname = `/manifest/${segments.join('/')}/manifest.json`;
+                } else {
+                    url.pathname = '/manifest.json';
                 }
-                if (settings.refreshInterval) params.set('refreshInterval', settings.refreshInterval);
-                if (settings.cacheTtl) params.set('cacheTtl', settings.cacheTtl);
-                if (settings.traktAccessToken) {
-                    params.set('traktAccessToken', settings.traktAccessToken);
-                }
-                if (settings.metadataAddon) params.set('metadataAddon', settings.metadataAddon);
-                url.search = params.toString();
                 return url.toString();
             }
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -50,13 +50,11 @@ def test_manifest_allows_path_overrides() -> None:
 
     with TestClient(app) as client:
         response = client.get(
-            "/manifest/catalogCount/5/catalogItems/9/manifest.json",
-            params={"catalogCount": "2"},
+            "/manifest/catalogCount/5/catalogItems/9/manifest.json"
         )
 
     assert response.status_code == 200
     assert service.last_config is not None
-    # Path-based overrides should take precedence over the query string.
     assert service.last_config.catalog_count == 5
     assert service.last_config.catalog_item_count == 9
 
@@ -68,5 +66,19 @@ def test_manifest_rejects_malformed_path_overrides() -> None:
 
     with TestClient(app) as client:
         response = client.get("/manifest/catalogCount/6/catalogItems/manifest.json")
+
+    assert response.status_code == 400
+
+
+def test_manifest_rejects_query_overrides() -> None:
+    app = FastAPI()
+    register_routes(app)
+    app.state.catalog_service = DummyCatalogService()
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/manifest.json",
+            params={"catalogCount": "3"},
+        )
 
     assert response.status_code == 400


### PR DESCRIPTION
## Summary
- reject manifest requests that use query string overrides
- update the config UI to build slash-delimited manifest URLs
- extend manifest tests to cover query-string rejection

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdbc79b0548322acfd4e58c8335c88