### PR TITLE
Ensure Trakt stats refresh after login

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -651,6 +651,7 @@ CONFIG_TEMPLATE = dedent(
                 updateTraktUi();
                 if (data.status === 'success' && traktAuth.accessToken) {
                     refreshTraktMessaging();
+                    void fetchProfileStatus({ useConfig: true });
                 } else if (data.status === 'success') {
                     showTraktStatus('Trakt did not return an access token. Please try again.', 'error');
                     showTraktHint('Approve the access request in the Trakt window to finish linking.');


### PR DESCRIPTION
## Summary
- reuse profile resolution in the status endpoint when config overrides differ so Trakt tokens and limits persist before returning status
- trigger a status refresh in the config UI after a successful Trakt login so stats appear without manual catalog generation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdbec216648322ac5c2440d19e3610