### PR TITLE
Derive manifest id from profile

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -134,11 +134,15 @@ def register_routes(fastapi_app: FastAPI) -> None:
             profile_state, catalogs = await service.list_manifest_catalogs(config)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+        manifest_suffix = getattr(profile_state, "id", None)
+        manifest_id = "com.aiopicks.python"
+        if isinstance(manifest_suffix, str) and manifest_suffix.strip():
+            manifest_id = f"{manifest_id}.{manifest_suffix.strip()}"
         manifest_name = (config.manifest_name or "").strip()
         if not manifest_name:
             manifest_name = settings.app_name
         return {
-            "id": "com.aiopicks.python",
+            "id": manifest_id,
             "version": "1.0.0",
             "name": manifest_name,
             "description": "Dynamic catalogs tailored to your Trakt history.",

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -20,7 +20,7 @@ class DummyCatalogService(CatalogService):
         self, config: ManifestConfig
     ) -> tuple[SimpleNamespace, list[dict[str, object]]]:
         self.last_config = config
-        state = SimpleNamespace(openrouter_model="test-model")
+        state = SimpleNamespace(openrouter_model="test-model", id="test-profile")
         return state, []
 
     def profile_id_from_catalog_id(self, catalog_id: str) -> str | None:  # pragma: no cover - not used
@@ -39,6 +39,7 @@ def test_manifest_advertises_only_catalog_resource() -> None:
 
     assert response.status_code == 200
     payload = response.json()
+    assert payload["id"] == "com.aiopicks.python.test-profile"
     assert payload["resources"] == ["catalog"]
 
 


### PR DESCRIPTION
## Summary
- derive the manifest identifier from the resolved profile id so each manifest URL returns a unique addon id
- extend manifest unit tests to cover the new identifier logic

## Testing
- pytest tests/test_manifest.py

------
https://chatgpt.com/codex/tasks/task_b_68cdc3745b2c83228480fb628c385bc1