### PR TITLE
Ensure profile status queries include stored profile id

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -993,8 +993,9 @@ CONFIG_TEMPLATE = dedent(
             function buildProfileQuery(options = {}) {
                 const { includeProfileId = true, includeConfig = false } = options;
                 const params = new URLSearchParams();
-                if (includeProfileId) {
-                    const profileId = resolveProfileId({ createIfMissing: true });
+                const shouldIncludeProfile = includeProfileId || includeConfig;
+                if (shouldIncludeProfile) {
+                    const profileId = resolveProfileId({ createIfMissing: includeProfileId });
                     if (profileId) {
                         params.set('profileId', profileId);
                     }


### PR DESCRIPTION
## Summary
- ensure the config page still sends a stored profile id when requesting profile status with configuration overrides

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdc4a7d2888322a328d3ef55e89957