### PR TITLE
Derive profile IDs from Trakt logins

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -315,7 +315,7 @@ def register_routes(fastapi_app: FastAPI) -> None:
                 )
             )
 
-        profile_id = service.determine_profile_id(config)
+        profile_id = await service.determine_profile_id(config)
         status = await service.get_profile_status(profile_id)
 
         def _requires_resolution(existing_status) -> bool:

--- a/app/services/trakt.py
+++ b/app/services/trakt.py
@@ -116,6 +116,36 @@ class TraktClient:
             return {}
         return data
 
+    async def fetch_user(
+        self,
+        *,
+        client_id: str | None = None,
+        access_token: str | None = None,
+    ) -> dict[str, Any]:
+        """Return the authenticated user's profile information."""
+
+        resolved_client_id = client_id or self._settings.trakt_client_id
+        resolved_access_token = access_token or self._settings.trakt_access_token
+
+        if not (resolved_client_id and resolved_access_token):
+            logger.info("Trakt credentials missing, returning anonymous profile")
+            return {}
+
+        response = await self._client.get(
+            "/users/me",
+            headers=self._headers(
+                client_id=resolved_client_id, access_token=resolved_access_token
+            ),
+        )
+        if response.status_code >= 400:
+            logger.warning("Failed to fetch Trakt user profile: %s", response.text)
+            return {}
+        data = response.json()
+        if not isinstance(data, dict):
+            logger.warning("Unexpected Trakt user profile structure")
+            return {}
+        return data
+
     @staticmethod
     def _extract_total_count(response: httpx.Response, *, fallback: int = 0) -> int:
         header_value = response.headers.get("x-pagination-item-count")


### PR DESCRIPTION
## Summary
- derive profile identifiers from the authenticated Trakt user when no explicit profile is supplied
- add a Trakt client helper for fetching the current user profile and hash tokens as a fallback
- await the asynchronous profile lookup in the status endpoint and cover the new behaviour with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdc745c0108322903bf5057c4c28d2