### PR TITLE
Refine OpenRouter prompt phrasing

### DIFF
--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -33,16 +33,17 @@ Trakt profile summary (generated at {generated_at} UTC):
 
 Instructions:
 1. Generate {catalog_count} movie catalogs AND {catalog_count} series catalogs.
-2. Use the random seed `{seed}` to introduce surprise (shuffle titles, invent novel themes).
+2. Use the random seed `{seed}` to introduce surprise—shuffle sequencing, bend genres, or surface overlooked regional scenes that still feel earned for this viewer.
 3. Each catalog must include EXACTLY {items_per_catalog} strong picks with real titles and release years.
 4. Keep each description to a single crisp sentence (max ~16 words) to conserve tokens, even when {items_per_catalog} is large.
-5. Craft each catalog title as a personal nod to this viewer—reference their standout genres, languages, or specific films/series they love so it feels like a friend calling back to their queue.
-6. Every title must include at least one concrete hook from their history (a cited title, city, language, character, actor, etc.) and steer clear of vague buzzwords like "gems", "discover", "explore", "must-watch", "binge", or "series to dive into".
+5. Craft each catalog title as a personal nod to this viewer—reference their standout genres, languages, or specific films/series they love while signalling the fresh angle you’re taking on their taste.
+6. Every title must include at least one concrete hook from their history (a cited title, city, language, character, actor, etc.) and steer clear of vague buzzwords or generic marketing phrases such as "action-packed", "epic journey", "gems", "discover", "explore", "must-watch", "binge", "series to dive into", or similar filler.
 7. Keep the titles confident and conversational without using tentative phrasing like "you may" or "you might". Vary the structure so no two titles recycle the same cadence, and never begin a title with "Your" or another possessive pronoun.
 8. Write titles in natural sentence case (capitalize the first word and proper nouns only), keeping the rest lower-case unless grammar requires otherwise.
-9. Treat the viewer's history as inspiration, not a shopping list—avoid repeating titles mentioned above unless a sequel or continuation is essential, and spotlight why each new pick connects to their tastes.
-10. Lean into discovery: ensure at least 60% of every catalog consists of fresh-to-viewer surprises rather than comfort rewatches.
-11. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with Cinemeta.
+9. Center each catalog on a vivid, specific micro-theme or narrative that ties back to their logged tastes while pushing them toward unexpected adjacent discoveries. Avoid broad buckets like "action adventures" or "fantasy journeys".
+10. Treat the viewer's history as inspiration, not a shopping list—avoid repeating titles mentioned above unless a sequel or continuation is essential, and spotlight why each new pick connects to their tastes.
+11. Lean into discovery: ensure at least 60% of every catalog consists of fresh-to-viewer surprises rather than comfort rewatches.
+12. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with Cinemeta.
 
 Respond with JSON using this structure:
 {{


### PR DESCRIPTION
## Summary
- adjust the surprise instruction to emphasize genre bending and regional discoveries tied to the seed
- remove the specific "late-night synth noir in neon Paris" example while keeping the micro-theme guidance strong
- restore the Cinemeta line to the concise wording requested for item metadata instructions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdd15f9c808322b193abcd92a01ae4