### PR TITLE
Speed up catalog refresh network calls

### DIFF
--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -444,17 +444,19 @@ class CatalogService:
             state.openrouter_model,
         )
 
-        movie_history_batch = await self._trakt.fetch_history(
-            "movies",
-            client_id=state.trakt_client_id,
-            access_token=state.trakt_access_token,
-            limit=state.trakt_history_limit,
-        )
-        show_history_batch = await self._trakt.fetch_history(
-            "shows",
-            client_id=state.trakt_client_id,
-            access_token=state.trakt_access_token,
-            limit=state.trakt_history_limit,
+        movie_history_batch, show_history_batch = await asyncio.gather(
+            self._trakt.fetch_history(
+                "movies",
+                client_id=state.trakt_client_id,
+                access_token=state.trakt_access_token,
+                limit=state.trakt_history_limit,
+            ),
+            self._trakt.fetch_history(
+                "shows",
+                client_id=state.trakt_client_id,
+                access_token=state.trakt_access_token,
+                limit=state.trakt_history_limit,
+            ),
         )
         movie_history = movie_history_batch.items
         show_history = show_history_batch.items
@@ -786,17 +788,19 @@ class CatalogService:
         if refreshed_at and datetime.utcnow() - refreshed_at < timedelta(hours=12):
             return state
 
-        movie_batch = await self._trakt.fetch_history(
-            "movies",
-            client_id=state.trakt_client_id,
-            access_token=state.trakt_access_token,
-            limit=1,
-        )
-        show_batch = await self._trakt.fetch_history(
-            "shows",
-            client_id=state.trakt_client_id,
-            access_token=state.trakt_access_token,
-            limit=1,
+        movie_batch, show_batch = await asyncio.gather(
+            self._trakt.fetch_history(
+                "movies",
+                client_id=state.trakt_client_id,
+                access_token=state.trakt_access_token,
+                limit=1,
+            ),
+            self._trakt.fetch_history(
+                "shows",
+                client_id=state.trakt_client_id,
+                access_token=state.trakt_access_token,
+                limit=1,
+            ),
         )
 
         movie_total, show_total, snapshot = await self._gather_trakt_history_metadata(

--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
@@ -246,8 +247,10 @@ class OpenRouterClient:
                     ", ".join(sorted(requests.keys())),
                 )
 
-        await _fill("movie", bundle.movie_catalogs)
-        await _fill("series", bundle.series_catalogs)
+        await asyncio.gather(
+            _fill("movie", bundle.movie_catalogs),
+            _fill("series", bundle.series_catalogs),
+        )
 
     def _prepare_top_up_requests(
         self,


### PR DESCRIPTION
## Summary
- fetch movie and series history from Trakt concurrently to shorten catalog refresh times
- parallelize OpenRouter catalog top-ups for movie and series lists to reduce total latency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdd34635f483228fe40d4933df04da