### PR TITLE
Drop items without Cinemeta metadata and retry 402

### DIFF
--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -894,18 +894,19 @@ class CatalogService:
                 continue
             matches[key] = result
 
-        if not matches:
-            return
-
+        looked_up_keys = set(lookup_tasks.keys())
         for catalog_map in catalogs.values():
             for catalog_id, catalog in list(catalog_map.items()):
                 updated_items: list[CatalogItem] = []
                 for item in catalog.items:
                     title = (item.title or "").strip()
                     if not title:
-                        updated_items.append(item)
+                        if item.imdb_id and item.poster:
+                            updated_items.append(item)
                         continue
                     key = (item.type, title.casefold(), item.year)
+                    if key in looked_up_keys and key not in matches:
+                        continue
                     match = matches.get(key)
                     if match is None:
                         updated_items.append(item)


### PR DESCRIPTION
## Summary
- retry Cinemeta lookups once after HTTP 402 responses before failing
- discard catalog items that still lack Cinemeta metadata after enrichment
- add regression tests covering the retry logic and item filtering behaviour

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68cdd6eae3e08322a8a311f56de532d4