### PR TITLE
Generalize metadata client beyond Cinemeta

### DIFF
--- a/app/services/metadata_addon.py
+++ b/app/services/metadata_addon.py
@@ -1,4 +1,4 @@
-"""Helper client for fetching metadata from Cinemeta."""
+"""Helper client for fetching metadata from Cinemeta-compatible add-ons."""
 
 from __future__ import annotations
 
@@ -16,8 +16,8 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(slots=True)
-class CinemetaMatch:
-    """Represents the useful fields returned from a Cinemeta search."""
+class MetadataMatch:
+    """Represents the useful fields returned from a metadata lookup."""
 
     id: str
     title: str
@@ -27,7 +27,7 @@ class CinemetaMatch:
     background: str | None = None
 
 
-class CinemetaClient:
+class MetadataAddonClient:
     """Wrapper around Cinemeta-compatible catalog search endpoints."""
 
     _SEARCH_PATH = "/catalog/{type}/top/search={query}.json"
@@ -54,8 +54,8 @@ class CinemetaClient:
         content_type: str,
         year: int | None = None,
         base_url: str | None = None,
-    ) -> CinemetaMatch | None:
-        """Return the best Cinemeta match for the given title/year."""
+    ) -> MetadataMatch | None:
+        """Return the best metadata match for the given title/year."""
 
         normalized_title = (title or "").strip()
         if not normalized_title:
@@ -86,7 +86,7 @@ class CinemetaClient:
                     await asyncio.sleep(0.1)
                     continue
                 logger.warning(
-                    "Cinemeta lookup failed for %s via %s: %s",
+                    "Metadata add-on lookup failed for %s via %s: %s",
                     normalized_title,
                     effective_base,
                     exc,
@@ -94,7 +94,7 @@ class CinemetaClient:
                 return None
             except httpx.HTTPError as exc:
                 logger.warning(
-                    "Cinemeta lookup failed for %s via %s: %s",
+                    "Metadata add-on lookup failed for %s via %s: %s",
                     normalized_title,
                     effective_base,
                     exc,
@@ -119,7 +119,7 @@ class CinemetaClient:
         if not match_id:
             return None
 
-        return CinemetaMatch(
+        return MetadataMatch(
             id=match_id,
             title=str(match.get("name") or normalized_title),
             type=str(match.get("type") or content_type),

--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -44,7 +44,7 @@ Instructions:
 9. Center each catalog on a vivid, specific micro-theme or narrative that ties back to their logged tastes while pushing them toward unexpected adjacent discoveries. Avoid broad buckets like "action adventures" or "fantasy journeys".
 10. Treat the viewer's history as inspiration, not a shopping list—avoid repeating titles mentioned above unless a sequel or continuation is essential, and spotlight why each new pick connects to their tastes.
 11. Lean into discovery: ensure at least 60% of every catalog consists of fresh-to-viewer surprises rather than comfort rewatches.
-12. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with Cinemeta.
+12. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with the configured metadata add-on (for example, Cinemeta).
 
 Respond with JSON using this structure:
 {{


### PR DESCRIPTION
## Summary
- rename the Cinemeta service module to a generic metadata add-on client and update imports
- teach the catalog service to use the renamed metadata client and adjust enrichment helpers
- refresh tests and prompts to reference the configurable metadata add-on instead of hard-coding Cinemeta

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cdd89335d0832289e02021a08d638b