### PR TITLE
Enhance personalization instructions in LLM prompt

### DIFF
--- a/app/services/openrouter.py
+++ b/app/services/openrouter.py
@@ -36,7 +36,7 @@ Instructions:
 2. Use the random seed `{seed}` to add gentle variety—shuffle sequencing or spotlight nearby corners of their taste without forcing jarring leaps.
 3. Each catalog must include EXACTLY {items_per_catalog} strong picks with real titles and release years.
 4. Keep each description to a single crisp sentence (max ~16 words) to conserve tokens, even when {items_per_catalog} is large.
-5. Title each catalog like a thoughtful recommendation from a cinephile friend; nod to the viewer’s signature loves only when it genuinely strengthens the hook.
+5. Title each catalog like a thoughtful recommendation from a cinephile friend; nod to the viewer’s signature loves only when it genuinely strengthens the hook and gently spotlight why the set feels made for them.
 6. Apply the following title craftsmanship rules to every catalog:
    - Create a specific, eye-catching theme in 4–8 words using simple, everyday language that anyone can understand, keeping the angle clear yet not overly narrow.
    - Make titles vivid, unique, and conversational—mix short punchy phrasing with more descriptive flows without sounding promotional.
@@ -48,7 +48,7 @@ Instructions:
    - Keep grammar clean, flow natural, and avoid overusing pronouns like "their", "them", or "why"; make the titles feel like recommendations a friend would share.
 7. Keep titles confident and conversational, steer clear of marketing fluff, and never open with "Your" or another possessive pronoun.
 8. Ground every catalog in a clear, taste-aligned theme that a real fan would recognize, avoiding contrived genre mash-ups or whiplash pivots.
-9. Let each description briefly explain why the picks belong together, focusing on tone, craft, or shared sensibilities that match the viewer.
+9. Let each description briefly explain why the picks belong together, focusing on tone, craft, or shared sensibilities that match the viewer, and speak directly to them with a warm second-person voice that references the provided taste signals when helpful.
 10. Treat the viewer's history as inspiration, not a shopping list—lean on the taste signals above and avoid repeating the recent standout titles unless a sequel or continuation is essential.
 11. Lean into discovery: ensure at least 60% of every catalog consists of fresh-to-viewer surprises rather than comfort rewatches.
 12. For each item include only its real title, type, release year, and a concise description. Do not invent IDs, posters, or runtimes—the server enriches entries with the configured metadata add-on (for example, Cinemeta).


### PR DESCRIPTION
## Summary
- tweak the catalog generation prompt to spotlight why each set feels tailored to the viewer
- require catalog descriptions to address the viewer directly using taste signals for warmer personalization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68ce9ba9cae0832295ff6975ba2c9fc1