### PR TITLE
Add configurable discovery blueprints for catalog generation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -39,6 +39,18 @@ class Settings(BaseSettings):
     catalog_item_count: int = Field(
         default=8, alias="CATALOG_ITEM_COUNT", ge=1, le=100
     )
+    enable_movie_catalogs: bool = Field(
+        default=True, alias="ENABLE_MOVIE_CATALOGS"
+    )
+    enable_series_catalogs: bool = Field(
+        default=True, alias="ENABLE_SERIES_CATALOGS"
+    )
+    catalog_rotation_mode: Literal["refresh", "expand"] = Field(
+        default="refresh", alias="CATALOG_ROTATION_MODE"
+    )
+    suggestion_cooldown_days: int = Field(
+        default=45, alias="SUGGESTION_COOLDOWN_DAYS", ge=0, le=365
+    )
     refresh_interval_seconds: int = Field(
         default=43_200, alias="REFRESH_INTERVAL", ge=3_600
     )

--- a/app/database.py
+++ b/app/database.py
@@ -91,6 +91,42 @@ class Database:
             "trakt_history_snapshot",
             "ALTER TABLE profiles ADD COLUMN trakt_history_snapshot JSON",
         )
+        _ensure_column(
+            "enable_movie_catalogs",
+            "ALTER TABLE profiles ADD COLUMN enable_movie_catalogs BOOLEAN DEFAULT 1",
+            (
+                "UPDATE profiles SET enable_movie_catalogs = 1 "
+                "WHERE enable_movie_catalogs IS NULL"
+            ),
+        )
+        _ensure_column(
+            "enable_series_catalogs",
+            "ALTER TABLE profiles ADD COLUMN enable_series_catalogs BOOLEAN DEFAULT 1",
+            (
+                "UPDATE profiles SET enable_series_catalogs = 1 "
+                "WHERE enable_series_catalogs IS NULL"
+            ),
+        )
+        _ensure_column(
+            "catalog_rotation_mode",
+            "ALTER TABLE profiles ADD COLUMN catalog_rotation_mode VARCHAR(20) DEFAULT 'refresh'",
+            (
+                "UPDATE profiles SET catalog_rotation_mode = 'refresh' "
+                "WHERE catalog_rotation_mode IS NULL"
+            ),
+        )
+        _ensure_column(
+            "suggestion_cooldown_days",
+            "ALTER TABLE profiles ADD COLUMN suggestion_cooldown_days INTEGER DEFAULT 45",
+            (
+                "UPDATE profiles SET suggestion_cooldown_days = 45 "
+                "WHERE suggestion_cooldown_days IS NULL"
+            ),
+        )
+        _ensure_column(
+            "discovery_blueprints",
+            "ALTER TABLE profiles ADD COLUMN discovery_blueprints JSON",
+        )
 
     async def dispose(self) -> None:
         """Dispose of the underlying database engine."""

--- a/app/discovery.py
+++ b/app/discovery.py
@@ -1,0 +1,488 @@
+"""Discovery lane blueprints that guide catalog generation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from .utils import slugify
+
+
+@dataclass(frozen=True)
+class DiscoveryBlueprint:
+    """Represents a curated discovery lane configuration."""
+
+    id: str
+    label: str
+    description: str
+    movie_prompt: str | None = None
+    series_prompt: str | None = None
+    priority: int = 0
+
+    def supports(self, content_type: str) -> bool:
+        """Return whether the blueprint can produce catalogs for the type."""
+
+        if content_type == "movie":
+            return self.movie_prompt is not None
+        if content_type == "series":
+            return self.series_prompt is not None
+        return False
+
+    def prompt_for(self, content_type: str) -> str | None:
+        """Return the instruction text for the requested content type."""
+
+        if content_type == "movie":
+            return self.movie_prompt
+        if content_type == "series":
+            return self.series_prompt
+        return None
+
+
+DISCOVERY_BLUEPRINTS: Mapping[str, DiscoveryBlueprint] = {
+    blueprint.id: blueprint
+    for blueprint in [
+        DiscoveryBlueprint(
+            id="streaming-launchpad",
+            label="Streaming launchpad",
+            description=(
+                "Brand-new streaming exclusives and day-and-date drops arriving right now"
+                " so viewers can press play the moment they open the app."
+            ),
+            movie_prompt=(
+                "Surface feature-length streaming premieres released in the past eight weeks,"
+                " focusing on originals or day-and-date debuts that just hit major platforms"
+                " in the viewer's region. Skip library pickups or titles that have circulated"
+                " for months."
+            ),
+            series_prompt=(
+                "Highlight streaming-exclusive series with seasons launching in the last eight"
+                " weeks, prioritising originals debuting all episodes or rolling out now."
+                " Avoid long-running back catalogue arrivals."
+            ),
+            priority=110,
+        ),
+        DiscoveryBlueprint(
+            id="fresh-premieres",
+            label="Fresh premieres",
+            description=(
+                "Festival darlings and prestige premieres that landed on streaming or digital"
+                " platforms within the last twelve months."
+            ),
+            movie_prompt=(
+                "Spotlight films that premiered in the past 12 months (festival debuts count"
+                " if they're just hitting VOD or streaming). Prioritise critically approved"
+                " releases that haven't had time to become catalog staples."
+            ),
+            series_prompt=(
+                "Feature series that launched or dropped a new season within the past six"
+                " months, favouring titles that only recently became bingeable on major"
+                " services."
+            ),
+            priority=90,
+        ),
+        DiscoveryBlueprint(
+            id="award-season-radar",
+            label="Award season radar",
+            description=(
+                "Buzz-heavy contenders from the current awards cycle that only just became"
+                " easy to watch at home."
+            ),
+            movie_prompt=(
+                "Curate films from the ongoing awards season (released within the past nine"
+                " months) earning major nominations or critics' prizes and newly available"
+                " to rent or stream."
+            ),
+            series_prompt=(
+                "Select limited series or prestige seasons premiering in this awards window"
+                " (within nine months) that critics celebrate yet remain fresh to general"
+                " audiences."
+            ),
+            priority=95,
+        ),
+        DiscoveryBlueprint(
+            id="festival-circuit",
+            label="Festival circuit heat",
+            description=(
+                "Award-courting films fresh from Sundance, TIFF, Cannes, or Berlinale now"
+                " rolling into general release."
+            ),
+            movie_prompt=(
+                "Curate recent festival standouts (last 18 months) that either secured awards"
+                " or exceptional buzz and only just became available to rent or stream."
+            ),
+            priority=85,
+        ),
+        DiscoveryBlueprint(
+            id="sleeper-streamer-hits",
+            label="Sleeper streamer hits",
+            description=(
+                "Under-the-radar originals that debuted recently and are building organic"
+                " buzz despite limited promotion."
+            ),
+            movie_prompt=(
+                "Identify streamer-original films released in the past six months with strong"
+                " audience chatter or critical praise yet low mainstream awareness, ensuring"
+                " they only just landed on the platform."
+            ),
+            series_prompt=(
+                "Pick new streamer-original series (last six months) seeing high completion"
+                " or social buzz inside fandoms but little top-list exposure; focus on first"
+                " seasons or soft reboots."
+            ),
+            priority=88,
+        ),
+        DiscoveryBlueprint(
+            id="global-breakouts",
+            label="Global breakouts",
+            description=(
+                "International sensations and under-the-radar imports drawing fresh chatter"
+                " among enthusiasts."
+            ),
+            movie_prompt=(
+                "Select international films (released within ~24 months) building momentum"
+                " with Western critics or fan communities but unlikely to be in their history."
+            ),
+            series_prompt=(
+                "Highlight new or returning series from outside their primary region that"
+                " critics and global fandoms are buzzing about this year."
+            ),
+            priority=80,
+        ),
+        DiscoveryBlueprint(
+            id="future-cult-classics",
+            label="Future cult classics",
+            description=(
+                "Bold storytelling swings from the past two years destined to become cult"
+                " favourites."
+            ),
+            movie_prompt=(
+                "Pick daring genre or auteur-driven films from the last two years that built"
+                " passionate early audiences yet remain largely undiscovered."
+            ),
+            series_prompt=(
+                "Serve up ambitious serialized stories (2023 onward) gaining strong word of"
+                " mouth among superfans but still early in their cultural ascent."
+            ),
+            priority=70,
+        ),
+        DiscoveryBlueprint(
+            id="breakout-debut-filmmakers",
+            label="Breakout debut filmmakers",
+            description=(
+                "First or second features from emerging directors that critics say you should"
+                " catch early."
+            ),
+            movie_prompt=(
+                "Spotlight first or second narrative features released in the past 18 months"
+                " whose directors are being hailed as new voices, and which only recently"
+                " arrived on VOD or streaming."
+            ),
+            priority=78,
+        ),
+        DiscoveryBlueprint(
+            id="documentary-pulse",
+            label="Documentary pulse",
+            description=(
+                "Edge-of-your-seat true stories premiering recently across film festivals and"
+                " prestige streamers."
+            ),
+            movie_prompt=(
+                "Gather cinematic documentaries released in the past 18 months that deliver"
+                " gripping narratives, investigative scoops, or cultural revelations."
+            ),
+            series_prompt=(
+                "Spotlight limited docu-series or anthology seasons debuting in the last year"
+                " with buzzy journalism or true-crime hooks."
+            ),
+            priority=65,
+        ),
+        DiscoveryBlueprint(
+            id="family-premiere-night",
+            label="Family premiere night",
+            description=(
+                "All-ages crowd-pleasers that just premiered so households can discover them"
+                " together for the first time."
+            ),
+            movie_prompt=(
+                "Select new family-friendly films (last 12 months) rated PG or PG-13 that"
+                " just debuted on streaming, prioritising four-quadrant adventures and"
+                " animated standouts that haven't saturated the zeitgeist yet."
+            ),
+            series_prompt=(
+                "Highlight new seasons or debuts of family and YA series from the past six"
+                " months that are fresh arrivals on major platforms and easy to start from"
+                " episode one."
+            ),
+            priority=62,
+        ),
+        DiscoveryBlueprint(
+            id="animation-vanguard",
+            label="Animation vanguard",
+            description=(
+                "Inventive animated storytelling from worldwide studios making noise right"
+                " now."
+            ),
+            movie_prompt=(
+                "Recommend animated films from the past two release cycles pushing visual or"
+                " narrative boundaries and only recently landing on home platforms."
+            ),
+            series_prompt=(
+                "Curate new-season or freshly launched animated series for adults and older"
+                " teens that critics are celebrating in the current cycle."
+            ),
+            priority=55,
+        ),
+        DiscoveryBlueprint(
+            id="genre-heatwave",
+            label="Genre heatwave",
+            description=(
+                "High-energy thrillers, horror, and speculative adventures lighting up feeds"
+                " over the last year."
+            ),
+            movie_prompt=(
+                "Deliver propulsive thrillers, horror, or sci-fi releases from the past 18"
+                " months that genre tastemakers champion yet remain fresh to the viewer."
+            ),
+            series_prompt=(
+                "Surface bingeable genre series (new launches or seasons since 2023) that fan"
+                " communities rave about but aren't mainstream staples yet."
+            ),
+            priority=50,
+        ),
+        DiscoveryBlueprint(
+            id="true-story-sagas",
+            label="True-story sagas",
+            description=(
+                "Recent fact-based dramas and limited series exploring gripping real events."
+            ),
+            movie_prompt=(
+                "Find dramatic features from the past two years rooted in true events that"
+                " critics praise for fresh perspective or daring execution."
+            ),
+            series_prompt=(
+                "Recommend limited or returning series (past 18 months) dramatizing real"
+                " figures or incidents with strong reviews yet limited saturation."
+            ),
+            priority=45,
+        ),
+        DiscoveryBlueprint(
+            id="fresh-season-rush",
+            label="Fresh season rush",
+            description=(
+                "Brand-new seasons or debuts exploding across conversation this quarter."
+            ),
+            series_prompt=(
+                "Zero in on series with seasons premiering in the last 3-4 months whose buzz"
+                " is still climbing, ensuring at least half are brand-new debuts."
+            ),
+            priority=75,
+        ),
+        DiscoveryBlueprint(
+            id="short-binge-series",
+            label="Weekend limited binges",
+            description=(
+                "Tight limited series or mini-seasons that can be finished in a weekend and"
+                " premiered recently."
+            ),
+            series_prompt=(
+                "Select newly released (past 12 months) limited or mini-series totalling 10"
+                " episodes or fewer, perfect for a single-weekend dive."
+            ),
+            priority=60,
+        ),
+        DiscoveryBlueprint(
+            id="weekly-warmers",
+            label="Weekly warmers",
+            description=(
+                "Easy-going network and streamer comedies or dramas that premiered this"
+                " season and make a breezy weeknight watch."
+            ),
+            series_prompt=(
+                "Highlight feel-good or procedural-leaning shows that premiered in the last"
+                " year, emphasising fresh comfort watches the viewer hasn't sampled."
+            ),
+            priority=40,
+        ),
+        DiscoveryBlueprint(
+            id="sci-fi-frontier",
+            label="Sci-fi frontier",
+            description=(
+                "Cutting-edge speculative stories from the past year pushing daring futuristic"
+                " ideas into the spotlight."
+            ),
+            movie_prompt=(
+                "Curate science-fiction films from the last 12 months exploring bold concepts"
+                " or technology, favouring fresh festival-to-streaming arrivals over legacy"
+                " franchise sequels."
+            ),
+            series_prompt=(
+                "Feature serialized sci-fi shows with seasons premiering since 2023 that"
+                " lean into ambitious world-building and only recently hit streaming."
+            ),
+            priority=52,
+        ),
+    ]
+}
+
+
+DEFAULT_MOVIE_BLUEPRINTS: Sequence[str] = (
+    "streaming-launchpad",
+    "fresh-premieres",
+    "award-season-radar",
+    "global-breakouts",
+    "sleeper-streamer-hits",
+    "future-cult-classics",
+    "festival-circuit",
+    "documentary-pulse",
+    "genre-heatwave",
+    "animation-vanguard",
+    "true-story-sagas",
+    "breakout-debut-filmmakers",
+    "family-premiere-night",
+    "sci-fi-frontier",
+)
+
+DEFAULT_SERIES_BLUEPRINTS: Sequence[str] = (
+    "streaming-launchpad",
+    "fresh-season-rush",
+    "award-season-radar",
+    "global-breakouts",
+    "sleeper-streamer-hits",
+    "future-cult-classics",
+    "genre-heatwave",
+    "documentary-pulse",
+    "short-binge-series",
+    "weekly-warmers",
+    "family-premiere-night",
+    "fresh-premieres",
+    "true-story-sagas",
+    "animation-vanguard",
+    "sci-fi-frontier",
+)
+
+
+def get_blueprint(blueprint_id: str) -> DiscoveryBlueprint | None:
+    """Return the blueprint if it exists."""
+
+    key = slugify(blueprint_id)
+    if not key:
+        return None
+    return DISCOVERY_BLUEPRINTS.get(key)
+
+
+def blueprint_options(content_type: str) -> list[DiscoveryBlueprint]:
+    """Return blueprints supporting the requested content type sorted by priority."""
+
+    return sorted(
+        (blueprint for blueprint in DISCOVERY_BLUEPRINTS.values() if blueprint.supports(content_type)),
+        key=lambda entry: entry.priority,
+        reverse=True,
+    )
+
+
+def blueprint_options_payload(content_type: str) -> list[dict[str, str]]:
+    """Return a serialisable blueprint catalog for UI payloads."""
+
+    payload: list[dict[str, str]] = []
+    for blueprint in blueprint_options(content_type):
+        payload.append(
+            {
+                "id": blueprint.id,
+                "label": blueprint.label,
+                "description": blueprint.description,
+            }
+        )
+    return payload
+
+
+def default_blueprint_ids(content_type: str) -> list[str]:
+    """Return the default ordered selection for the content type."""
+
+    if content_type == "movie":
+        return list(DEFAULT_MOVIE_BLUEPRINTS)
+    if content_type == "series":
+        return list(DEFAULT_SERIES_BLUEPRINTS)
+    return []
+
+
+def sanitize_blueprint_selection(
+    selection: Iterable[str] | None, content_type: str
+) -> list[str]:
+    """Normalise user provided blueprint identifiers."""
+
+    if selection is None:
+        return []
+    seen: set[str] = set()
+    normalised: list[str] = []
+    for raw in selection:
+        if not isinstance(raw, str):
+            continue
+        key = slugify(raw)
+        if not key or key in seen:
+            continue
+        blueprint = DISCOVERY_BLUEPRINTS.get(key)
+        if blueprint is None or not blueprint.supports(content_type):
+            continue
+        seen.add(key)
+        normalised.append(key)
+    return normalised
+
+
+def selection_from_payload(
+    payload: Mapping[str, object] | None, content_type: str
+) -> list[str]:
+    """Return a cleaned selection from a persisted JSON payload."""
+
+    if not isinstance(payload, Mapping):
+        return default_blueprint_ids(content_type)
+    key = "movie" if content_type == "movie" else "series"
+    if key not in payload:
+        return default_blueprint_ids(content_type)
+    raw_value = payload.get(key)
+    if raw_value is None:
+        return default_blueprint_ids(content_type)
+    if isinstance(raw_value, str):
+        raw_items: Sequence[str] = [part.strip() for part in raw_value.split(",")]
+    elif isinstance(raw_value, Sequence):
+        raw_items = [str(item) for item in raw_value]
+    else:
+        raw_items = []
+    cleaned = sanitize_blueprint_selection(raw_items, content_type)
+    if cleaned:
+        return cleaned
+    # Explicit empty list should be respected; fall back only when payload was malformed.
+    if isinstance(raw_value, Sequence) and not raw_value:
+        return []
+    return default_blueprint_ids(content_type)
+
+
+def build_selection_payload(
+    *, movie: Sequence[str], series: Sequence[str]
+) -> dict[str, list[str]]:
+    """Return a serialisable payload for persistence."""
+
+    return {
+        "movie": sanitize_blueprint_selection(movie, "movie"),
+        "series": sanitize_blueprint_selection(series, "series"),
+    }
+
+
+def summarise_blueprints(
+    blueprints: Sequence[DiscoveryBlueprint], content_type: str
+) -> list[dict[str, str]]:
+    """Return summary payloads suitable for prompt construction."""
+
+    summary: list[dict[str, str]] = []
+    for blueprint in blueprints:
+        prompt = blueprint.prompt_for(content_type)
+        if not prompt:
+            continue
+        summary.append(
+            {
+                "id": blueprint.id,
+                "label": blueprint.label,
+                "description": blueprint.description,
+                "prompt": prompt,
+            }
+        )
+    return summary

--- a/app/main.py
+++ b/app/main.py
@@ -23,6 +23,7 @@ from .services.catalog_generator import ManifestConfig
 from .services.openrouter import OpenRouterClient
 from .services.trakt import TraktClient
 from .web import render_config_page
+from .discovery import sanitize_blueprint_selection
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -314,6 +315,12 @@ def register_routes(fastapi_app: FastAPI) -> None:
                     cfg.trakt_client_id,
                     cfg.trakt_access_token,
                     cfg.metadata_addon_url,
+                    cfg.movies_enabled,
+                    cfg.series_enabled,
+                    cfg.rotation_mode,
+                    cfg.suggestion_cooldown_days,
+                    cfg.movie_blueprints,
+                    cfg.series_blueprints,
                 )
             )
 
@@ -374,6 +381,42 @@ def register_routes(fastapi_app: FastAPI) -> None:
                 metadata_url = str(config.metadata_addon_url)
                 if (state.metadata_addon_url or None) != metadata_url:
                     return True
+            if (
+                config.movies_enabled is not None
+                and state.enable_movie_catalogs != config.movies_enabled
+            ):
+                return True
+            if (
+                config.series_enabled is not None
+                and state.enable_series_catalogs != config.series_enabled
+            ):
+                return True
+            if (
+                config.rotation_mode is not None
+                and state.rotation_mode != config.rotation_mode
+            ):
+                return True
+            if (
+                config.suggestion_cooldown_days is not None
+                and state.suggestion_cooldown_days != config.suggestion_cooldown_days
+            ):
+                return True
+            if (
+                config.movie_blueprints is not None
+                and state.movie_blueprints
+                != sanitize_blueprint_selection(
+                    config.movie_blueprints, "movie"
+                )
+            ):
+                return True
+            if (
+                config.series_blueprints is not None
+                and state.series_blueprints
+                != sanitize_blueprint_selection(
+                    config.series_blueprints, "series"
+                )
+            ):
+                return True
             return False
 
         if _requires_resolution(status):

--- a/app/web.py
+++ b/app/web.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 from urllib.parse import urlparse
 
 from .config import Settings
+from .discovery import blueprint_options_payload, default_blueprint_ids
 
 
 CONFIG_TEMPLATE = dedent(
@@ -103,6 +104,88 @@ CONFIG_TEMPLATE = dedent(
             font-weight: 400;
             font-size: 0.85rem;
             color: var(--text-muted);
+        }
+        .option-row {
+            display: flex;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+        }
+        .option-row label {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-weight: 500;
+        }
+        .option-row input[type="checkbox"] {
+            width: 1.1rem;
+            height: 1.1rem;
+        }
+        .blueprint-list {
+            display: flex;
+            flex-direction: column;
+            gap: 0.65rem;
+        }
+        .blueprint-item {
+            border: 1px solid var(--outline);
+            border-radius: 14px;
+            padding: 0.75rem 0.9rem;
+            background: var(--surface-muted);
+            transition: border 0.2s ease, background 0.2s ease;
+        }
+        .blueprint-item.selected {
+            border-color: var(--outline-strong);
+            background: rgba(255, 255, 255, 0.04);
+        }
+        .blueprint-header {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.75rem;
+            align-items: center;
+        }
+        .blueprint-header label {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            gap: 0.65rem;
+            font-weight: 600;
+        }
+        .blueprint-header input[type="checkbox"] {
+            width: 1.1rem;
+            height: 1.1rem;
+        }
+        .blueprint-actions {
+            display: inline-flex;
+            gap: 0.35rem;
+            align-items: center;
+        }
+        .blueprint-order {
+            min-width: 1.5rem;
+            text-align: center;
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+        .blueprint-actions button {
+            background: transparent;
+            border: 1px solid var(--outline);
+            color: var(--text-muted);
+            border-radius: 8px;
+            padding: 0.2rem 0.4rem;
+            font-size: 0.75rem;
+            line-height: 1;
+            min-width: 1.75rem;
+        }
+        .blueprint-actions button:hover:not(:disabled) {
+            border-color: var(--accent);
+            color: var(--accent);
+        }
+        .blueprint-actions button:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+        .blueprint-description {
+            margin: 0.45rem 0 0;
+            color: var(--text-muted);
+            font-size: 0.85rem;
         }
         input[type="text"],
         select {
@@ -344,6 +427,13 @@ CONFIG_TEMPLATE = dedent(
                     <input id="config-catalog-count" type="range" min="1" max="12" step="1" />
                 </div>
                 <div class="field">
+                    <label>Catalog types</label>
+                    <div class="option-row">
+                        <label><input id="config-enable-movies" type="checkbox" checked /> Movie rows</label>
+                        <label><input id="config-enable-series" type="checkbox" checked /> Series rows</label>
+                    </div>
+                </div>
+                <div class="field">
                     <label for="config-catalog-items">Items per catalog <span class="range-value" id="catalog-items-value"></span></label>
                     <input id="config-catalog-items" type="range" min="4" max="100" step="1" />
                 </div>
@@ -368,6 +458,25 @@ CONFIG_TEMPLATE = dedent(
                         <option value="1800">30 minutes</option>
                         <option value="3600">60 minutes</option>
                     </select>
+                </div>
+                <div class="field">
+                    <label for="config-rotation-mode">Row rotation <span class="helper">Keep catalog IDs stable to avoid reinstalling</span></label>
+                    <select id="config-rotation-mode">
+                        <option value="refresh">Keep row IDs, swap picks</option>
+                        <option value="expand">Mint new rows on each refresh</option>
+                    </select>
+                </div>
+                <div class="field">
+                    <label for="config-suggestion-cooldown">Discovery cooldown <span class="helper">Minimum days before resurfacing a title</span> <span class="range-value" id="suggestion-cooldown-value"></span></label>
+                    <input id="config-suggestion-cooldown" type="range" min="0" max="180" step="5" />
+                </div>
+                <div class="field">
+                    <label>Movie discovery lanes <span class="helper">Select and reorder the AI-generated rows</span></label>
+                    <div class="blueprint-list" id="movie-blueprint-list"></div>
+                </div>
+                <div class="field">
+                    <label>Series discovery lanes <span class="helper">Select and reorder the AI-generated rows</span></label>
+                    <div class="blueprint-list" id="series-blueprint-list"></div>
                 </div>
                 <div class="actions">
                     <button id="prepare-profile" type="button">
@@ -395,10 +504,15 @@ CONFIG_TEMPLATE = dedent(
             const catalogValue = document.getElementById('catalog-count-value');
             const catalogItemsSlider = document.getElementById('config-catalog-items');
             const catalogItemsValue = document.getElementById('catalog-items-value');
+            const moviesToggle = document.getElementById('config-enable-movies');
+            const seriesToggle = document.getElementById('config-enable-series');
             const historySlider = document.getElementById('config-history-limit');
             const historyValue = document.getElementById('history-limit-value');
             const refreshSelect = document.getElementById('config-refresh-interval');
             const cacheSelect = document.getElementById('config-cache-ttl');
+            const rotationSelect = document.getElementById('config-rotation-mode');
+            const suggestionSlider = document.getElementById('config-suggestion-cooldown');
+            const suggestionValue = document.getElementById('suggestion-cooldown-value');
             const prepareProfileButton = document.getElementById('prepare-profile');
             const prepareSpinner = document.getElementById('prepare-spinner');
             const prepareLabel = prepareProfileButton.querySelector('.label');
@@ -408,6 +522,13 @@ CONFIG_TEMPLATE = dedent(
             const copyMessage = document.getElementById('copy-message');
             const manifestStatus = document.getElementById('manifest-status');
             const manifestLock = document.getElementById('manifest-lock');
+            const movieBlueprintList = document.getElementById('movie-blueprint-list');
+            const seriesBlueprintList = document.getElementById('series-blueprint-list');
+            const blueprintOptions = defaults.blueprintOptions || { movie: [], series: [] };
+            const blueprintState = {
+                movie: { selected: sanitizeBlueprintSelection('movie', defaults.movieBlueprints || []) },
+                series: { selected: sanitizeBlueprintSelection('series', defaults.seriesBlueprints || []) },
+            };
 
             const traktLoginButton = document.getElementById('trakt-login');
             const traktDisconnectButton = document.getElementById('trakt-disconnect');
@@ -418,6 +539,12 @@ CONFIG_TEMPLATE = dedent(
             const traktStatsShows = document.getElementById('trakt-stats-shows');
             const traktStatsSummary = document.getElementById('trakt-stats-summary');
             const traktStatsUpdated = document.getElementById('trakt-stats-updated');
+            let moviesToggleTouched = false;
+            let seriesToggleTouched = false;
+            let rotationTouched = false;
+            let suggestionTouched = false;
+            let movieBlueprintsTouched = false;
+            let seriesBlueprintsTouched = false;
             const traktLoginAvailable = Boolean(defaults.traktLoginAvailable);
             const traktCallbackOrigin = (defaults.traktCallbackOrigin || '').trim();
             const traktOrigins = [window.location.origin];
@@ -432,6 +559,8 @@ CONFIG_TEMPLATE = dedent(
             let preparePending = false;
             let profileStatus = null;
             let statusPollTimer = null;
+
+            renderBlueprintLists();
 
             const profileStorageKey = 'aiopicks.profileId';
             let persistedProfileId = readStoredProfileId();
@@ -517,6 +646,20 @@ CONFIG_TEMPLATE = dedent(
             const defaultCatalogItems = defaults.catalogItemCount || catalogItemsSlider.min || 4;
             catalogItemsSlider.value = defaultCatalogItems;
             catalogItemsValue.textContent = catalogItemsSlider.value;
+            if (typeof defaults.moviesEnabled === 'boolean') {
+                moviesToggle.checked = defaults.moviesEnabled;
+            }
+            if (typeof defaults.seriesEnabled === 'boolean') {
+                seriesToggle.checked = defaults.seriesEnabled;
+            }
+            const rotationDefault = (defaults.rotationMode || 'refresh').toLowerCase();
+            rotationSelect.value = rotationDefault === 'expand' ? 'expand' : 'refresh';
+            const defaultCooldownRaw = Number(defaults.suggestionCooldownDays);
+            const cooldownValue = Number.isFinite(defaultCooldownRaw)
+                ? defaultCooldownRaw
+                : Number(suggestionSlider.value || suggestionSlider.min || 0);
+            suggestionSlider.value = String(cooldownValue);
+            suggestionValue.textContent = formatCooldownDays(cooldownValue);
             const resolvedHistoryLimit =
                 defaults.traktHistoryLimit || historySlider.value || historySlider.max || 1000;
             historySlider.value = resolvedHistoryLimit;
@@ -555,12 +698,39 @@ CONFIG_TEMPLATE = dedent(
                 markProfileDirty();
                 updateManifestPreview();
             });
+            moviesToggle.addEventListener('change', () => {
+                moviesToggleTouched = true;
+                markProfileDirty();
+                updateManifestPreview();
+                renderBlueprintLists();
+                updateManifestUi();
+                updateManifestStatus();
+            });
+            seriesToggle.addEventListener('change', () => {
+                seriesToggleTouched = true;
+                markProfileDirty();
+                updateManifestPreview();
+                renderBlueprintLists();
+                updateManifestUi();
+                updateManifestStatus();
+            });
             historySlider.addEventListener('input', () => {
                 historyLimitTouched = true;
                 historyValue.textContent = formatHistoryLimit(historySlider.value);
                 markProfileDirty();
                 updateManifestPreview();
                 updateTraktStats();
+            });
+            rotationSelect.addEventListener('change', () => {
+                rotationTouched = true;
+                markProfileDirty();
+                updateManifestPreview();
+            });
+            suggestionSlider.addEventListener('input', () => {
+                suggestionTouched = true;
+                suggestionValue.textContent = formatCooldownDays(suggestionSlider.value);
+                markProfileDirty();
+                updateManifestPreview();
             });
             openrouterModel.addEventListener('input', () => {
                 markProfileDirty();
@@ -790,6 +960,10 @@ CONFIG_TEMPLATE = dedent(
                     setManifestStatus('Generating catalogs… this typically takes under a minute.');
                     return;
                 }
+                if (!moviesToggle.checked && !seriesToggle.checked) {
+                    setManifestStatus('Enable movie or series rows to generate catalogs.', 'error');
+                    return;
+                }
                 if (!profileStatus) {
                     setManifestStatus('Adjust the settings and click “Generate catalogs” to warm your manifest URL.');
                     return;
@@ -837,7 +1011,8 @@ CONFIG_TEMPLATE = dedent(
             function updateManifestUi() {
                 const traktLocked = traktLoginAvailable && !traktAuth.accessToken;
                 const generating = preparePending || Boolean(profileStatus && profileStatus.refreshing);
-                prepareProfileButton.disabled = traktLocked || generating;
+                const contentLocked = !moviesToggle.checked && !seriesToggle.checked;
+                prepareProfileButton.disabled = traktLocked || generating || contentLocked;
                 prepareProfileButton.classList.toggle('loading', generating);
                 prepareProfileButton.setAttribute('aria-busy', generating ? 'true' : 'false');
                 if (prepareSpinner) {
@@ -936,6 +1111,17 @@ CONFIG_TEMPLATE = dedent(
                         history.stats = normalisedStats;
                     }
                 }
+                const blueprintRaw = raw.discoveryBlueprints && typeof raw.discoveryBlueprints === 'object'
+                    ? raw.discoveryBlueprints
+                    : {};
+                const buildBlueprintSection = (type) => {
+                    const section = blueprintRaw[type] && typeof blueprintRaw[type] === 'object'
+                        ? blueprintRaw[type]
+                        : {};
+                    const selected = Array.isArray(section.selected) ? section.selected : [];
+                    const available = Array.isArray(section.available) ? section.available : [];
+                    return { selected, available };
+                };
                 return {
                     profileId,
                     hasCatalogs: Boolean(raw.hasCatalogs),
@@ -949,6 +1135,16 @@ CONFIG_TEMPLATE = dedent(
                         : '',
                     traktHistoryLimit: Number.isFinite(historyLimit) && historyLimit > 0 ? historyLimit : 0,
                     traktHistory: history,
+                    moviesEnabled: raw.moviesEnabled !== false,
+                    seriesEnabled: raw.seriesEnabled !== false,
+                    rotationMode: typeof raw.rotationMode === 'string' ? raw.rotationMode : 'refresh',
+                    suggestionCooldownDays: Number.isFinite(Number(raw.suggestionCooldownDays))
+                        ? Number(raw.suggestionCooldownDays)
+                        : Number(suggestionSlider.value || defaults.suggestionCooldownDays || 0),
+                    discoveryBlueprints: {
+                        movie: buildBlueprintSection('movie'),
+                        series: buildBlueprintSection('series'),
+                    },
                 };
             }
 
@@ -959,10 +1155,20 @@ CONFIG_TEMPLATE = dedent(
                     metadataAddon: metadataAddonInput.value.trim(),
                     catalogCount: catalogSlider.value,
                     catalogItems: catalogItemsSlider.value,
+                    moviesEnabled: moviesToggle.checked ? '1' : '0',
+                    seriesEnabled: seriesToggle.checked ? '1' : '0',
                     traktHistoryLimit: historySlider.value,
                     refreshInterval: refreshSelect.value,
                     cacheTtl: cacheSelect.value,
+                    rotationMode: rotationSelect.value,
+                    suggestionCooldown: suggestionSlider.value,
                     traktAccessToken: traktAuth.accessToken,
+                    movieBlueprints: moviesToggle.checked
+                        ? [...blueprintState.movie.selected]
+                        : [],
+                    seriesBlueprints: seriesToggle.checked
+                        ? [...blueprintState.series.selected]
+                        : [],
                 };
             }
 
@@ -980,13 +1186,25 @@ CONFIG_TEMPLATE = dedent(
                 if (settings.openrouterModel) payload.openrouterModel = settings.openrouterModel;
                 if (settings.catalogCount) payload.catalogCount = Number(settings.catalogCount);
                 if (settings.catalogItems) payload.catalogItems = Number(settings.catalogItems);
+                if (settings.moviesEnabled !== undefined) payload.moviesEnabled = settings.moviesEnabled;
+                if (settings.seriesEnabled !== undefined) payload.seriesEnabled = settings.seriesEnabled;
                 if (settings.traktHistoryLimit) {
                     payload.traktHistoryLimit = Number(settings.traktHistoryLimit);
                 }
                 if (settings.refreshInterval) payload.refreshInterval = Number(settings.refreshInterval);
                 if (settings.cacheTtl) payload.cacheTtl = Number(settings.cacheTtl);
+                if (settings.rotationMode) payload.rotationMode = settings.rotationMode;
+                if (settings.suggestionCooldown !== undefined) {
+                    payload.suggestionCooldown = Number(settings.suggestionCooldown);
+                }
                 if (settings.traktAccessToken) payload.traktAccessToken = settings.traktAccessToken;
                 if (settings.metadataAddon) payload.metadataAddon = settings.metadataAddon;
+                if (settings.movieBlueprints !== undefined) {
+                    payload.movieBlueprints = settings.movieBlueprints;
+                }
+                if (settings.seriesBlueprints !== undefined) {
+                    payload.seriesBlueprints = settings.seriesBlueprints;
+                }
                 return payload;
             }
 
@@ -1003,7 +1221,11 @@ CONFIG_TEMPLATE = dedent(
                 if (includeConfig) {
                     const settings = collectManifestSettings();
                     Object.entries(settings).forEach(([key, value]) => {
-                        if (value) {
+                        if (Array.isArray(value)) {
+                            params.set(key, value.length ? value.join(',') : '-');
+                            return;
+                        }
+                        if (value !== undefined && value !== null && value !== '') {
                             params.set(key, value);
                         }
                     });
@@ -1041,6 +1263,7 @@ CONFIG_TEMPLATE = dedent(
                     }
                     profileStatus = normalized;
                     syncHistoryLimitFromStatus();
+                    syncPreferencesFromStatus();
                     updateManifestPreview();
                     updateManifestUi();
                     updateManifestStatus();
@@ -1082,6 +1305,7 @@ CONFIG_TEMPLATE = dedent(
                     }
                     profileStatus = normalized;
                     syncHistoryLimitFromStatus();
+                    syncPreferencesFromStatus();
                     updateManifestPreview();
                     updateManifestUi();
                     updateManifestStatus();
@@ -1112,15 +1336,27 @@ CONFIG_TEMPLATE = dedent(
                     'metadataAddon',
                     'catalogCount',
                     'catalogItems',
+                    'moviesEnabled',
+                    'seriesEnabled',
                     'traktHistoryLimit',
                     'refreshInterval',
                     'cacheTtl',
+                    'rotationMode',
+                    'suggestionCooldown',
                     'traktAccessToken',
+                    'movieBlueprints',
+                    'seriesBlueprints',
                 ];
                 const segments = [];
                 manifestKeys.forEach((key) => {
                     const value = settings[key];
-                    if (!value) {
+                    if (Array.isArray(value)) {
+                        const encodedValue = value.length ? value.join(',') : '-';
+                        segments.push(encodeURIComponent(key));
+                        segments.push(encodeURIComponent(encodedValue));
+                        return;
+                    }
+                    if (value === undefined || value === null || value === '') {
                         return;
                     }
                     segments.push(encodeURIComponent(key));
@@ -1136,6 +1372,199 @@ CONFIG_TEMPLATE = dedent(
 
             function updateManifestPreview() {
                 manifestPreview.textContent = buildConfiguredUrl();
+            }
+
+            function renderBlueprintLists() {
+                renderBlueprintList('movie', movieBlueprintList, moviesToggle.checked);
+                renderBlueprintList('series', seriesBlueprintList, seriesToggle.checked);
+            }
+
+            function renderBlueprintList(type, container, enabled) {
+                if (!container) {
+                    return;
+                }
+                const options = blueprintOptions[type] || [];
+                const selected = blueprintState[type] ? blueprintState[type].selected : [];
+                container.innerHTML = '';
+                if (!options.length) {
+                    const empty = document.createElement('p');
+                    empty.className = 'muted';
+                    empty.textContent = 'No discovery lanes available yet.';
+                    container.appendChild(empty);
+                    return;
+                }
+                options.forEach((option) => {
+                    const item = document.createElement('div');
+                    item.className = 'blueprint-item';
+                    item.dataset.id = option.id;
+                    const index = selected.indexOf(option.id);
+                    const isSelected = index !== -1;
+                    if (isSelected) {
+                        item.classList.add('selected');
+                    }
+
+                    const header = document.createElement('div');
+                    header.className = 'blueprint-header';
+
+                    const label = document.createElement('label');
+                    const checkbox = document.createElement('input');
+                    checkbox.type = 'checkbox';
+                    checkbox.checked = isSelected;
+                    checkbox.disabled = !enabled;
+                    checkbox.addEventListener('change', () => {
+                        toggleBlueprint(type, option.id, checkbox.checked);
+                    });
+                    label.appendChild(checkbox);
+                    const title = document.createElement('span');
+                    title.textContent = option.label || option.id;
+                    label.appendChild(title);
+                    header.appendChild(label);
+
+                    const actions = document.createElement('div');
+                    actions.className = 'blueprint-actions';
+                    const orderBadge = document.createElement('span');
+                    orderBadge.className = 'blueprint-order';
+                    orderBadge.textContent = isSelected ? String(index + 1) : '–';
+                    actions.appendChild(orderBadge);
+
+                    const upButton = document.createElement('button');
+                    upButton.type = 'button';
+                    upButton.textContent = '↑';
+                    upButton.title = 'Move up';
+                    upButton.disabled = !enabled || !isSelected || index === 0;
+                    upButton.addEventListener('click', () => {
+                        reorderBlueprint(type, option.id, -1);
+                    });
+                    actions.appendChild(upButton);
+
+                    const downButton = document.createElement('button');
+                    downButton.type = 'button';
+                    downButton.textContent = '↓';
+                    downButton.title = 'Move down';
+                    downButton.disabled = !enabled || !isSelected || index === selected.length - 1;
+                    downButton.addEventListener('click', () => {
+                        reorderBlueprint(type, option.id, 1);
+                    });
+                    actions.appendChild(downButton);
+
+                    header.appendChild(actions);
+                    item.appendChild(header);
+
+                    if (option.description) {
+                        const description = document.createElement('p');
+                        description.className = 'blueprint-description';
+                        description.textContent = option.description;
+                        item.appendChild(description);
+                    }
+
+                    container.appendChild(item);
+                });
+            }
+
+            function toggleBlueprint(type, blueprintId, enabled) {
+                const state = blueprintState[type];
+                if (!state) {
+                    return;
+                }
+                const next = [...state.selected];
+                const index = next.indexOf(blueprintId);
+                if (enabled && index === -1) {
+                    next.push(blueprintId);
+                } else if (!enabled && index !== -1) {
+                    next.splice(index, 1);
+                }
+                state.selected = sanitizeBlueprintSelection(type, next);
+                if (type === 'movie') {
+                    movieBlueprintsTouched = true;
+                } else {
+                    seriesBlueprintsTouched = true;
+                }
+                renderBlueprintLists();
+                updateManifestPreview();
+                updateManifestUi();
+                updateManifestStatus();
+            }
+
+            function reorderBlueprint(type, blueprintId, delta) {
+                const state = blueprintState[type];
+                if (!state) {
+                    return;
+                }
+                const next = [...state.selected];
+                const index = next.indexOf(blueprintId);
+                if (index === -1) {
+                    return;
+                }
+                const target = index + delta;
+                if (target < 0 || target >= next.length) {
+                    return;
+                }
+                const [entry] = next.splice(index, 1);
+                next.splice(target, 0, entry);
+                state.selected = next;
+                if (type === 'movie') {
+                    movieBlueprintsTouched = true;
+                } else {
+                    seriesBlueprintsTouched = true;
+                }
+                renderBlueprintLists();
+                updateManifestPreview();
+                updateManifestUi();
+                updateManifestStatus();
+            }
+
+            function sanitizeBlueprintSelection(type, selection) {
+                const options = blueprintOptions[type] || [];
+                const validIds = new Set(options.map((option) => option.id).filter(Boolean));
+                const clean = [];
+                if (Array.isArray(selection)) {
+                    selection.forEach((value) => {
+                        if (typeof value !== 'string') {
+                            return;
+                        }
+                        const trimmed = value.trim();
+                        if (!trimmed || !validIds.has(trimmed) || clean.includes(trimmed)) {
+                            return;
+                        }
+                        clean.push(trimmed);
+                    });
+                }
+                return clean;
+            }
+
+            function syncBlueprintsFromStatus() {
+                if (!profileStatus) {
+                    return;
+                }
+                const raw = profileStatus.discoveryBlueprints && typeof profileStatus.discoveryBlueprints === 'object'
+                    ? profileStatus.discoveryBlueprints
+                    : {};
+
+                ['movie', 'series'].forEach((type) => {
+                    const section = raw[type] && typeof raw[type] === 'object' ? raw[type] : {};
+                    if (Array.isArray(section.available) && section.available.length) {
+                        blueprintOptions[type] = section.available
+                            .map((option) => ({
+                                id: typeof option.id === 'string' ? option.id : '',
+                                label: typeof option.label === 'string' ? option.label : '',
+                                description: typeof option.description === 'string' ? option.description : '',
+                            }))
+                            .filter((option) => option.id);
+                    }
+                    const touched = type === 'movie' ? movieBlueprintsTouched : seriesBlueprintsTouched;
+                    if (!touched && Array.isArray(section.selected)) {
+                        blueprintState[type].selected = sanitizeBlueprintSelection(
+                            type,
+                            section.selected,
+                        );
+                    } else {
+                        blueprintState[type].selected = sanitizeBlueprintSelection(
+                            type,
+                            blueprintState[type].selected,
+                        );
+                    }
+                });
+                renderBlueprintLists();
             }
 
             function syncHistoryLimitFromStatus() {
@@ -1155,6 +1584,32 @@ CONFIG_TEMPLATE = dedent(
                     historySlider.value = String(limit);
                 }
                 historyValue.textContent = formatHistoryLimit(limit);
+            }
+
+            function syncPreferencesFromStatus() {
+                if (!profileStatus) {
+                    return;
+                }
+                if (!moviesToggleTouched && typeof profileStatus.moviesEnabled === 'boolean') {
+                    moviesToggle.checked = profileStatus.moviesEnabled;
+                }
+                if (!seriesToggleTouched && typeof profileStatus.seriesEnabled === 'boolean') {
+                    seriesToggle.checked = profileStatus.seriesEnabled;
+                }
+                if (!rotationTouched && profileStatus.rotationMode) {
+                    const value = profileStatus.rotationMode === 'expand' ? 'expand' : 'refresh';
+                    rotationSelect.value = value;
+                }
+                if (!suggestionTouched) {
+                    const cooldown = Number(profileStatus.suggestionCooldownDays);
+                    if (Number.isFinite(cooldown) && cooldown >= 0) {
+                        suggestionSlider.value = String(cooldown);
+                        suggestionValue.textContent = formatCooldownDays(cooldown);
+                    }
+                }
+                syncBlueprintsFromStatus();
+                updateManifestUi();
+                updateManifestStatus();
             }
 
             async function copyToClipboard(value) {
@@ -1189,6 +1644,20 @@ CONFIG_TEMPLATE = dedent(
                     return '';
                 }
                 return `${numberFormatter.format(Math.round(numeric))} plays`;
+            }
+
+            function formatCooldownDays(value) {
+                const numeric = Number(value);
+                if (!Number.isFinite(numeric) || numeric < 0) {
+                    return '';
+                }
+                if (numeric === 0) {
+                    return 'Off';
+                }
+                if (numeric === 1) {
+                    return '1 day';
+                }
+                return `${numeric} days`;
             }
 
             function formatSeconds(seconds) {
@@ -1458,9 +1927,13 @@ def render_config_page(settings: Settings, *, callback_origin: str = "") -> str:
         "openrouterModel": settings.openrouter_model,
         "catalogCount": settings.catalog_count,
         "catalogItemCount": settings.catalog_item_count,
+        "moviesEnabled": settings.enable_movie_catalogs,
+        "seriesEnabled": settings.enable_series_catalogs,
         "traktHistoryLimit": settings.trakt_history_limit,
         "refreshIntervalSeconds": settings.refresh_interval_seconds,
         "responseCacheSeconds": settings.response_cache_seconds,
+        "rotationMode": settings.catalog_rotation_mode,
+        "suggestionCooldownDays": settings.suggestion_cooldown_days,
         "traktAccessToken": settings.trakt_access_token or "",
         "traktLoginAvailable": bool(
             settings.trakt_client_id and settings.trakt_client_secret
@@ -1469,6 +1942,12 @@ def render_config_page(settings: Settings, *, callback_origin: str = "") -> str:
         "metadataAddon": (
             str(settings.metadata_addon_url) if settings.metadata_addon_url else ""
         ),
+        "blueprintOptions": {
+            "movie": blueprint_options_payload("movie"),
+            "series": blueprint_options_payload("series"),
+        },
+        "movieBlueprints": default_blueprint_ids("movie"),
+        "seriesBlueprints": default_blueprint_ids("series"),
     }
     defaults_json = json.dumps(defaults).replace("</", "<\\/")
 


### PR DESCRIPTION
## Summary
- add first-class discovery blueprints with persisted profile selections
- honour blueprint choices in catalog generation, OpenRouter prompts, and manifest output
- refresh the /config UI for lane selection and cover the behaviour with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cef65cd88c832294f5b7b3632e3f1e