### PR TITLE
Add configurable retry budget for AI catalog generation

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,10 @@ class Settings(BaseSettings):
         default=1_800, alias="CACHE_TTL", ge=300
     )
 
+    generation_retry_limit: int = Field(
+        default=3, alias="GENERATION_RETRY_LIMIT", ge=0, le=10
+    )
+
     trakt_api_url: HttpUrl = Field(
         default="https://api.trakt.tv", alias="TRAKT_API_URL"
     )

--- a/app/db_models.py
+++ b/app/db_models.py
@@ -34,6 +34,7 @@ class Profile(Base):
     )
     catalog_count: Mapped[int] = mapped_column(Integer, default=STABLE_CATALOG_COUNT)
     catalog_item_count: Mapped[int] = mapped_column(Integer, default=8)
+    generation_retry_limit: Mapped[int] = mapped_column(Integer, default=3)
     refresh_interval_seconds: Mapped[int] = mapped_column(Integer, default=43_200)
     response_cache_seconds: Mapped[int] = mapped_column(Integer, default=1_800)
     metadata_addon_url: Mapped[str | None] = mapped_column(String(512), nullable=True)

--- a/tests/test_catalog_service.py
+++ b/tests/test_catalog_service.py
@@ -218,6 +218,7 @@ def test_profile_status_payload_flags() -> None:
         trakt_client_id=None,
         trakt_access_token=None,
         catalog_item_count=12,
+        generation_retry_limit=3,
         refresh_interval_seconds=3600,
         response_cache_seconds=600,
         trakt_history_limit=1_000,

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -57,6 +57,20 @@ def test_manifest_allows_path_overrides() -> None:
     assert service.last_config.catalog_item_count == 9
 
 
+def test_manifest_allows_retry_override() -> None:
+    app = FastAPI()
+    register_routes(app)
+    service = DummyCatalogService()
+    app.state.catalog_service = service
+
+    with TestClient(app) as client:
+        response = client.get("/manifest/generationRetries/5/manifest.json")
+
+    assert response.status_code == 200
+    assert service.last_config is not None
+    assert service.last_config.generation_retry_limit == 5
+
+
 def test_manifest_rejects_malformed_path_overrides() -> None:
     app = FastAPI()
     register_routes(app)


### PR DESCRIPTION
## Summary
- add a configurable generation retry limit to settings, profile storage, and status payloads
- ensure the OpenRouter client respects the retry budget when topping up catalogs
- expose the retry control in the configuration UI and accept manifest overrides, with updated tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d06b12cb3c83229635f729827f2460