### PR TITLE
Clarify response cache purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ below lists the most relevant options:
 | `CATALOG_ITEM_COUNT` | `8` | Number of items the AI should return for each lane. |
 | `GENERATION_RETRY_LIMIT` | `3` | Extra attempts allowed when lanes return too few results. |
 | `REFRESH_INTERVAL` | `43200` (12h) | How often the background worker re-generates catalogs per profile. |
-| `CACHE_TTL` | `1800` (30m) | How long catalog responses stay cached before expiring. |
+| `CACHE_TTL` | `1800` (30m) | How long Stremio reuses the last catalog response before asking the server again. (Catalogs still regenerate on the `REFRESH_INTERVAL` schedule.) |
 | `METADATA_ADDON_URL` | – | Base URL for the Stremio-compatible metadata source used to enrich items. |
 | `DATABASE_URL` | `sqlite+aiosqlite:///./aiopicks.db` | Location of the SQLite database that stores profiles and catalogs. |
 | `APP_NAME` | `AIOPicks` | Display name surfaced in the manifest and config UI. |

--- a/app/web.py
+++ b/app/web.py
@@ -361,7 +361,7 @@ CONFIG_TEMPLATE = dedent(
                     </select>
                 </div>
                 <div class="field">
-                    <label for="config-cache-ttl">Response cache <span class="helper">Stremio responses stay fresh for...</span></label>
+                    <label for="config-cache-ttl">Response cache <span class="helper">How long Stremio reuses the last response before refetching (AI refresh uses the cadence above)</span></label>
                     <select id="config-cache-ttl">
                         <option value="300">5 minutes</option>
                         <option value="900">15 minutes</option>


### PR DESCRIPTION
## Summary
- clarify the README description so response cache is distinguished from the refresh cadence
- update the /config UI helper copy to explain that the cache only controls Stremio reuse of a response

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d07a10b5748322b7dce554a0c19e1c