### PR TITLE
Allow deeper Trakt history limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ below lists the most relevant options:
 | `OPENROUTER_MODEL` | – | Model identifier requested from OpenRouter (configurable per profile). |
 | `TRAKT_CLIENT_ID` / `TRAKT_CLIENT_SECRET` | – | Credentials needed for device authentication from the config UI. |
 | `TRAKT_ACCESS_TOKEN` | – | Optional long-lived token if you prefer to preconfigure the profile without using the UI. |
-| `TRAKT_HISTORY_LIMIT` | `1000` | Maximum Trakt history items stored for exclusions (10–2000). |
+| `TRAKT_HISTORY_LIMIT` | `1000` | Maximum Trakt history items stored for exclusions (10–10,000). |
 | `CATALOG_ITEM_COUNT` | `8` | Number of items the AI should return for each lane. |
 | `GENERATION_RETRY_LIMIT` | `3` | Extra attempts allowed when lanes return too few results. |
 | `REFRESH_INTERVAL` | `43200` (12h) | How often the background worker re-generates catalogs per profile. |

--- a/app/config.py
+++ b/app/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
         default=None, alias="TRAKT_REDIRECT_URI"
     )
     trakt_history_limit: int = Field(
-        default=2_000, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000
+        default=2_000, alias="TRAKT_HISTORY_LIMIT", ge=10, le=10_000
     )
 
     openrouter_api_key: str | None = Field(

--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -83,7 +83,7 @@ class ManifestConfig(BaseModel):
     trakt_history_limit: int | None = Field(
         default=None,
         ge=10,
-        le=2000,
+        le=10_000,
         validation_alias=AliasChoices("traktHistoryLimit", "historyLimit"),
     )
     trakt_client_id: str | None = Field(

--- a/app/web.py
+++ b/app/web.py
@@ -349,7 +349,7 @@ CONFIG_TEMPLATE = dedent(
                 </div>
                 <div class="field">
                     <label for="config-history-limit">History depth <span class="helper">How many recent plays to filter duplicates</span> <span class="range-value" id="history-limit-value"></span></label>
-                    <input id="config-history-limit" type="range" min="100" max="2000" step="50" />
+                    <input id="config-history-limit" type="range" min="100" max="10000" step="50" />
                 </div>
                 <div class="field">
                     <label for="config-refresh-interval">Refresh cadence <span class="helper">How often the AI rethinks the catalogs</span></label>


### PR DESCRIPTION
## Summary
- raise the Trakt history limit validation ceiling to 10,000 and document the broader range
- expand the config UI history slider so profiles can request the higher depth

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d07b9194248322aae4a8c5bd7c8cb6