### PR TITLE
Fetch full Trakt history with pagination

### DIFF
--- a/app/services/trakt.py
+++ b/app/services/trakt.py
@@ -62,29 +62,84 @@ class TraktClient:
         resolved_access_token = access_token or self._settings.trakt_access_token
 
         if not (resolved_client_id and resolved_access_token):
-            logger.info("Trakt credentials missing, returning empty history for %s", content_type)
+            logger.info(
+                "Trakt credentials missing, returning empty history for %s",
+                content_type,
+            )
+            return HistoryBatch(items=[], total=0, fetched=False)
+
+        try:
+            resolved_limit = int(
+                limit if limit is not None else self._settings.trakt_history_limit
+            )
+        except (TypeError, ValueError):
+            resolved_limit = self._settings.trakt_history_limit
+
+        if resolved_limit <= 0:
             return HistoryBatch(items=[], total=0, fetched=False)
 
         url = f"/sync/history/{content_type}"
-        resolved_limit = limit if limit is not None else self._settings.trakt_history_limit
-        params = {
-            "limit": resolved_limit,
-            "extended": "full",
-        }
-        response = await self._client.get(
-            url,
-            headers=self._headers(client_id=resolved_client_id, access_token=resolved_access_token),
-            params=params,
-        )
-        if response.status_code >= 400:
-            logger.warning("Failed to fetch Trakt history for %s: %s", content_type, response.text)
+        items: list[dict[str, Any]] = []
+        fetched_any = False
+        total = 0
+        page = 1
+        total_pages: int | None = None
+
+        while len(items) < resolved_limit:
+            remaining = resolved_limit - len(items)
+            page_size = min(remaining, 100)
+            params = {
+                "limit": page_size,
+                "page": page,
+                "extended": "full",
+            }
+            response = await self._client.get(
+                url,
+                headers=self._headers(
+                    client_id=resolved_client_id, access_token=resolved_access_token
+                ),
+                params=params,
+            )
+            if response.status_code >= 400:
+                logger.warning(
+                    "Failed to fetch Trakt history for %s: %s",
+                    content_type,
+                    response.text,
+                )
+                break
+            data = response.json()
+            if not isinstance(data, list):
+                logger.warning(
+                    "Unexpected Trakt response structure for %s",
+                    content_type,
+                )
+                break
+
+            if not fetched_any:
+                total = self._extract_total_count(response, fallback=len(data))
+                total_pages = self._extract_page_count(response)
+
+            if not data:
+                break
+
+            items.extend(data)
+            fetched_any = True
+
+            if len(data) < page_size:
+                break
+
+            if total_pages is not None and page >= total_pages:
+                break
+
+            page += 1
+
+        if not fetched_any:
             return HistoryBatch(items=[], total=0, fetched=False)
-        data = response.json()
-        if not isinstance(data, list):
-            logger.warning("Unexpected Trakt response structure for %s", content_type)
-            return HistoryBatch(items=[], total=0, fetched=False)
-        total = self._extract_total_count(response, fallback=len(data))
-        return HistoryBatch(items=data, total=total, fetched=True)
+
+        if total <= 0:
+            total = len(items)
+
+        return HistoryBatch(items=items[:resolved_limit], total=total, fetched=True)
 
     async def fetch_stats(
         self,
@@ -155,6 +210,17 @@ class TraktClient:
             return int(header_value)
         except (TypeError, ValueError):
             return fallback
+
+    @staticmethod
+    def _extract_page_count(response: httpx.Response) -> int | None:
+        header_value = response.headers.get("x-pagination-page-count")
+        if not header_value:
+            return None
+        try:
+            value = int(header_value)
+        except (TypeError, ValueError):
+            return None
+        return value if value > 0 else None
 
     @staticmethod
     def summarize_history(history: list[dict[str, Any]], *, key: str) -> dict[str, Any]:

--- a/tests/test_trakt_client.py
+++ b/tests/test_trakt_client.py
@@ -1,0 +1,105 @@
+"""Tests for the Trakt API client helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import pytest
+
+from app.config import Settings
+from app.services.trakt import TraktClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Force AnyIO tests to run on asyncio without requiring trio."""
+
+    return "asyncio"
+
+
+def build_settings(**overrides: Any) -> Settings:
+    """Return a settings object with defaults suitable for tests."""
+
+    base = {
+        "TRAKT_CLIENT_ID": "client-id",
+        "TRAKT_ACCESS_TOKEN": "access-token",
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.anyio("asyncio")
+async def test_fetch_history_paginates_until_limit() -> None:
+    """The client should follow Trakt pagination to satisfy the requested limit."""
+
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        page = int(request.url.params.get("page", "1"))
+        limit = int(request.url.params.get("limit", "0"))
+        # Simulate two pages of history results capped at the requested limit.
+        if page > 2:
+            return httpx.Response(
+                200,
+                json=[],
+                headers={
+                    "x-pagination-item-count": "150",
+                    "x-pagination-page-count": "2",
+                },
+            )
+        start = (page - 1) * 100
+        items = [
+            {
+                "id": start + index + 1,
+                "watched_at": "2024-01-01T00:00:00.000Z",
+                "type": "movie",
+                "movie": {
+                    "title": f"Movie {start + index + 1}",
+                    "year": 2000,
+                    "ids": {
+                        "imdb": f"tt{start + index + 1:07d}",
+                        "trakt": start + index + 1,
+                    },
+                },
+            }
+            for index in range(limit)
+        ]
+        return httpx.Response(
+            200,
+            json=items,
+            headers={
+                "x-pagination-item-count": "150",
+                "x-pagination-page-count": "2",
+            },
+        )
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://api.example.com") as http_client:
+        client = TraktClient(build_settings(), http_client)
+        batch = await client.fetch_history("movies", limit=120)
+
+    assert batch.fetched is True
+    assert len(batch.items) == 120
+    assert batch.total == 150
+    assert requests[0].url.params["limit"] == "100"
+    assert requests[1].url.params["limit"] == "20"
+    assert len(requests) == 2
+
+
+@pytest.mark.anyio("asyncio")
+async def test_fetch_history_handles_error_response() -> None:
+    """HTTP failures should result in an empty history payload."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"error": "unavailable"})
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport, base_url="https://api.example.com") as http_client:
+        client = TraktClient(build_settings(), http_client)
+        batch = await client.fetch_history("movies", limit=50)
+
+    assert batch.fetched is False
+    assert batch.items == []
+    assert batch.total == 0


### PR DESCRIPTION
## Summary
- paginate Trakt history fetches so profiles honour the configured history limit instead of a single page
- stop early when the API signals no further pages and retain graceful fallbacks on malformed responses
- add coverage for paginated history retrieval and error handling in the Trakt client

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d08d37b1408322803053db61e05aa4