### PR TITLE
Expand Trakt history limit to 10000

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,7 @@ OPENROUTER_MODEL=google/gemini-2.5-flash-lite
 TRAKT_CLIENT_ID=replace-with-trakt-client-id
 TRAKT_CLIENT_SECRET=replace-with-trakt-client-secret
 TRAKT_ACCESS_TOKEN=replace-with-trakt-access-token
-# Increase if you want deeper history exclusion
+# Increase if you want deeper history exclusion (max 10000)
 TRAKT_HISTORY_LIMIT=1000
 # Optional: override the detected redirect URL if proxying through a custom domain
 TRAKT_REDIRECT_URI=https://your-domain.example/api/trakt/callback

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ AIOPicks currently generates 19 fixed lanes. Movies and series are requested sep
 
 ## ⚙️ How it works right now
 
-1. **Trakt ingestion** – The service pulls your configured amount of movie and series history (up to 2,000 entries each) together with statistics that help the UI surface watch-time totals.
+1. **Trakt ingestion** – The service pulls your configured amount of movie and series history (up to 10,000 entries each) together with statistics that help the UI surface watch-time totals.
 2. **Taste summary** – AIOPicks builds prompts summarising your favourite genres, people, and recent standouts while passing fingerprints of everything you have already logged so repeats can be filtered out.
 3. **AI generation** – Each lane is requested in parallel through OpenRouter, seeded with a random token so results rotate between refreshes while keeping the lane title stable.
 4. **Metadata enrichment** – When a Cinemeta-compatible metadata service URL is configured, missing posters, backgrounds, IDs, and release years are filled in before storing the catalogs.
@@ -72,7 +72,7 @@ AIOPicks currently generates 19 fixed lanes. Movies and series are requested sep
    - `TRAKT_CLIENT_ID`, `TRAKT_CLIENT_SECRET`, and a long-lived `TRAKT_ACCESS_TOKEN`
 3. Optional but recommended settings:
    - `OPENROUTER_MODEL` (defaults to `google/gemini-2.5-flash-lite`)
-   - `TRAKT_HISTORY_LIMIT` (default `1000`, max `2000` per type)
+   - `TRAKT_HISTORY_LIMIT` (default `1000`, max `10000` per type)
    - `CATALOG_ITEM_COUNT` (items per lane, default `8`)
    - `REFRESH_INTERVAL` (seconds between automatic refreshes, default `43200`)
    - `CACHE_TTL` (how long cached catalog responses stay valid, default `1800`)

--- a/app/config.py
+++ b/app/config.py
@@ -27,7 +27,7 @@ class Settings(BaseSettings):
         default=None, alias="TRAKT_REDIRECT_URI"
     )
     trakt_history_limit: int = Field(
-        default=1_000, alias="TRAKT_HISTORY_LIMIT", ge=10, le=2000
+        default=1_000, alias="TRAKT_HISTORY_LIMIT", ge=10, le=10_000
     )
 
     openrouter_api_key: str | None = Field(

--- a/app/services/catalog_generator.py
+++ b/app/services/catalog_generator.py
@@ -83,7 +83,7 @@ class ManifestConfig(BaseModel):
     trakt_history_limit: int | None = Field(
         default=None,
         ge=10,
-        le=2000,
+        le=10_000,
         validation_alias=AliasChoices("traktHistoryLimit", "historyLimit"),
     )
     trakt_client_id: str | None = Field(

--- a/app/web.py
+++ b/app/web.py
@@ -349,7 +349,7 @@ CONFIG_TEMPLATE = dedent(
                 </div>
                 <div class="field">
                     <label for="config-history-limit">History depth <span class="helper">How many recent plays to filter duplicates</span> <span class="range-value" id="history-limit-value"></span></label>
-                    <input id="config-history-limit" type="range" min="100" max="2000" step="50" />
+                    <input id="config-history-limit" type="range" min="100" max="10000" step="50" />
                 </div>
                 <div class="field">
                     <label for="config-refresh-interval">Refresh cadence <span class="helper">How often the AI rethinks the catalogs</span></label>


### PR DESCRIPTION
## Summary
- raise the allowable Trakt history limit ceiling to 10,000 entries across configuration surfaces
- refresh the config UI slider and documentation to mention the higher maximum

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d1b28f08408322b53c4b96252c52e9