### PR TITLE
Allow configuring generated catalog lanes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -4,11 +4,15 @@ from __future__ import annotations
 
 from functools import lru_cache
 from typing import Literal
+from collections.abc import Iterable, Sequence
 
-from pydantic import AliasChoices, Field, HttpUrl
+from pydantic import AliasChoices, Field, HttpUrl, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from .stable_catalogs import STABLE_CATALOG_COUNT
+from .stable_catalogs import STABLE_CATALOGS, STABLE_CATALOG_COUNT, StableCatalogDefinition
+
+
+DEFAULT_CATALOG_KEYS: tuple[str, ...] = tuple(definition.key for definition in STABLE_CATALOGS)
 
 
 class Settings(BaseSettings):
@@ -37,10 +41,14 @@ class Settings(BaseSettings):
         default="google/gemini-2.5-flash-lite", alias="OPENROUTER_MODEL"
     )
 
-    catalog_count: int = Field(
-        default=STABLE_CATALOG_COUNT,
+    catalog_keys: tuple[str, ...] = Field(
+        default=DEFAULT_CATALOG_KEYS,
+        alias="CATALOG_KEYS",
+    )
+    catalog_count: int | None = Field(
+        default=None,
         alias="CATALOG_COUNT",
-        ge=STABLE_CATALOG_COUNT,
+        ge=1,
         le=STABLE_CATALOG_COUNT,
     )
     catalog_item_count: int = Field(
@@ -85,6 +93,65 @@ class Settings(BaseSettings):
         """Maintain backwards compatibility with the previous setting name."""
 
         return self.metadata_addon_url
+
+    @property
+    def catalog_definitions(self) -> tuple[StableCatalogDefinition, ...]:
+        """Return the configured stable catalog definitions in order."""
+
+        definitions_by_key = {definition.key: definition for definition in STABLE_CATALOGS}
+        return tuple(definitions_by_key[key] for key in self.catalog_keys)
+
+    @field_validator("catalog_keys", mode="before")
+    @classmethod
+    def _parse_catalog_keys(cls, value: object) -> tuple[str, ...] | object:
+        """Parse raw catalog key inputs into a tuple of unique identifiers."""
+
+        if value is None or value == "":
+            return DEFAULT_CATALOG_KEYS
+
+        if isinstance(value, str):
+            candidates: Iterable[str] = (part.strip() for part in value.split(","))
+        elif isinstance(value, Sequence):
+            candidates = (str(part).strip() for part in value)
+        elif isinstance(value, Iterable):
+            candidates = (str(part).strip() for part in value)
+        else:
+            raise ValueError("CATALOG_KEYS must be a comma-separated string or list of keys")
+
+        filtered: list[str] = []
+        for candidate in candidates:
+            identifier = candidate.casefold()
+            if not identifier:
+                continue
+            if identifier not in filtered:
+                filtered.append(identifier)
+
+        if not filtered:
+            return DEFAULT_CATALOG_KEYS
+        return tuple(filtered)
+
+    @model_validator(mode="after")
+    def _validate_catalog_configuration(self) -> "Settings":
+        """Ensure configured catalogs line up with available stable definitions."""
+
+        if not self.catalog_keys:
+            raise ValueError("At least one catalog key must be configured")
+
+        available = {definition.key for definition in STABLE_CATALOGS}
+        invalid = sorted(set(self.catalog_keys) - available)
+        if invalid:
+            keys = ", ".join(invalid)
+            raise ValueError(f"Unknown catalog keys configured: {keys}")
+
+        resolved_count = len(self.catalog_keys)
+        if self.catalog_count is None:
+            object.__setattr__(self, "catalog_count", resolved_count)
+        elif self.catalog_count != resolved_count:
+            raise ValueError(
+                "CATALOG_COUNT must match the number of configured catalog keys"
+            )
+
+        return self
 
     model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8")
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,56 @@
+"""Configuration settings behaviour tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.config import Settings, DEFAULT_CATALOG_KEYS
+
+
+def test_catalog_keys_subset_selection() -> None:
+    """Settings should respect custom catalog key selections."""
+
+    settings = Settings(_env_file=None, CATALOG_KEYS="movies-for-you,actors-you-love")
+
+    assert settings.catalog_keys == ("movies-for-you", "actors-you-love")
+    assert settings.catalog_count == 2
+    assert [definition.key for definition in settings.catalog_definitions] == [
+        "movies-for-you",
+        "actors-you-love",
+    ]
+
+
+def test_catalog_keys_accepts_case_insensitive_values() -> None:
+    """Catalog keys should be parsed case-insensitively."""
+
+    settings = Settings(_env_file=None, CATALOG_KEYS=["Movies-For-You", "HIDDEN-GEMS"])
+
+    assert settings.catalog_keys == ("movies-for-you", "hidden-gems")
+    assert settings.catalog_count == 2
+
+
+def test_catalog_keys_blank_defaults() -> None:
+    """Blank catalog keys should fall back to the full stable set."""
+
+    settings = Settings(_env_file=None, CATALOG_KEYS="")
+
+    assert settings.catalog_keys == DEFAULT_CATALOG_KEYS
+    assert settings.catalog_count == len(DEFAULT_CATALOG_KEYS)
+
+
+def test_catalog_keys_invalid_raises() -> None:
+    """Unknown catalog keys should raise a validation error."""
+
+    with pytest.raises(ValueError, match="Unknown catalog keys configured"):
+        Settings(_env_file=None, CATALOG_KEYS="does-not-exist")
+
+
+def test_catalog_count_must_match_keys() -> None:
+    """Explicit catalog counts must match the selected keys."""
+
+    with pytest.raises(ValueError, match="must match the number of configured catalog keys"):
+        Settings(
+            _env_file=None,
+            CATALOG_KEYS="movies-for-you",
+            CATALOG_COUNT=2,
+        )


### PR DESCRIPTION
## Summary
- add a `CATALOG_KEYS` setting that controls which stable lanes are generated
- derive the catalog count from the selected keys and expose the filtered definitions to OpenRouter
- cover the new configuration behaviour with unit tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_b_68d1c7b646d083229454ab6da72fcca5